### PR TITLE
 Updating primitives names in models directory

### DIFF
--- a/models/ngspice/sm141064.ngspice
+++ b/models/ngspice/sm141064.ngspice
@@ -32,36 +32,36 @@
 *
 *      ModelName          Description
 *      ---------          -----------
-*      nmos_3p3           Subcircuit model for 3.3V NMOS
-*      pmos_3p3           Subcircuit model for 3.3V PMOS
-*      nmos_6p0           Subcircuit model for 6.0V NMOS
-*      pmos_6p0           Subcircuit model for 6.0V PMOS
-*      nmos_3p3_sab       Subcircuit model for 3.3V NMOS with Drain side SAB
-*      pmos_3p3_sab       Subcircuit model for 3.3V PMOS with Drain side SAB
-*      nmos_6p0_sab       Subcircuit model for 6.0V NMOS with Drain side SAB
-*      pmos_6p0_sab       Subcircuit model for 6.0V PMOS with Drain side SAB
-*      nmos_6p0_nat       Subcircuit model for 6.0V native NMOS
+*      nfet_03v3           Subcircuit model for 3.3V NMOS
+*      pfet_03v3           Subcircuit model for 3.3V PMOS
+*      nfet_06v0           Subcircuit model for 6.0V NMOS
+*      pfet_06v0           Subcircuit model for 6.0V PMOS
+*      nfet_03v3_dss       Subcircuit model for 3.3V NMOS with Drain side SAB
+*      pfet_03v3_dss       Subcircuit model for 3.3V PMOS with Drain side SAB
+*      nfet_06v0_dss       Subcircuit model for 6.0V NMOS with Drain side SAB
+*      pfet_06v0_dss       Subcircuit model for 6.0V PMOS with Drain side SAB
+*      nfet_06v0_nvt       Subcircuit model for 6.0V native NMOS
 *
-*      np_3p3             Model for 3.3V N+/Psub diode
-*      pn_3p3             Model for 3.3V P+/Nwell diode
-*      np_6p0             Model for 6.0V N+/Psub diode
-*      pn_6p0             Model for 6.0V P+/Nwell diode
-*      nwp_3p3            Model for 3.3V Nwell/Psub diode
-*      nwp_6p0            Model for 6.0V Nwell/Psub diode
-*      dnwpw              Model for PWELL/DNWELL diode
-*      dnwps	          Model for DNWELL/Psub diode
+*      diode_nd2ps_03v3             Model for 3.3V N+/Psub diode
+*      diode_pd2nw_03v3             Model for 3.3V P+/Nwell diode
+*      diode_nd2ps_06v0             Model for 6.0V N+/Psub diode
+*      diode_pd2nw_06v0             Model for 6.0V P+/Nwell diode
+*      diode_nw2ps_03v3            Model for 3.3V Nwell/Psub diode
+*      diode_nw2ps_06v0            Model for 6.0V Nwell/Psub diode
+*      diode_pw2dw              Model for PWELL/DNWELL diode
+*      diode_dw2ps	          Model for DNWELL/Psub diode
 *      sc_diode           Model for Schottky Diode
 *
-*      vpnp_0p42x10       Subcircuit GP model for VPNP with emitter size of 10umx0.42um
-*      vpnp_0p42x5        Subcircuit GP model for VPNP with emitter size of 5umx0.42um
-*      vpnp_10x10         Subcircuit GP model for VPNP with emitter size of 10umx10um
-*      vpnp_5x5           Subcircuit GP model for VPNP with emitter size of 5umx5um
-*      vnpn_10x10         Subcircuit GP model for VNPN with emitter size of 10umx10um(four terminal)
-*      vnpn_5x5        	  Subcircuit GP model for VNPN with emitter size of 5umx5um(four terminal)
-*      vnpn_0p54x16       Subcircuit GP model for VNPN with emitter size of 0.54umx16um(four terminal)
-*      vnpn_0p54x8        Subcircuit GP model for VNPN with emitter size of 0.54umx8um(four terminal)
-*      vnpn_0p54x4        Subcircuit GP model for VNPN with emitter size of 0.54umx4um(four terminal)
-*      vnpn_0p54x2        Subcircuit GP model for VNPN with emitter size of 0.54umx2um(four terminal)
+*      pnp_10p00x00p42       Subcircuit GP model for VPNP with emitter size of 10umx0.42um
+*      pnp_05p00x00p42        Subcircuit GP model for VPNP with emitter size of 5umx0.42um
+*      pnp_10p00x10p00         Subcircuit GP model for VPNP with emitter size of 10umx10um
+*      pnp_05p00x05p00           Subcircuit GP model for VPNP with emitter size of 5umx5um
+*      npn_10p00x10p00         Subcircuit GP model for VNPN with emitter size of 10umx10um(four terminal)
+*      npn_05p00x05p00        	  Subcircuit GP model for VNPN with emitter size of 5umx5um(four terminal)
+*      npn_00p54x16p00       Subcircuit GP model for VNPN with emitter size of 0.54umx16um(four terminal)
+*      npn_00p54x08p00        Subcircuit GP model for VNPN with emitter size of 0.54umx8um(four terminal)
+*      npn_00p54x04p00        Subcircuit GP model for VNPN with emitter size of 0.54umx4um(four terminal)
+*      npn_00p54x02p00        Subcircuit GP model for VNPN with emitter size of 0.54umx2um(four terminal)
 *
 *      nplus_u            Subcircuit Model for 3-terminal unsalicided n+ diffusion resistor
 *      pplus_u            Subcircuit Model for 3-terminal unsalicided P+ diffusion resistor
@@ -85,192 +85,192 @@
 *      tm11k              Subcircuit Model for 2-terminal top metal 11k resistor
 *      tm30k              Subcircuit Model for 2-terminal top metal 30k resistor
 *
-*      mim_1p5fF          Subcircuit Model for 1.5fF/um2 MIM (*)-usable for Volt <=6V across capacitor
-*      mim_1p0fF          Subcircuit Model for 1.0fF/um2 MIM (*)-usable for Volt <=20V across capacitor 
-*      mim_2p0fF          Subcircuit Model for 2fF/um2 MIM      -usable for Volt <=6V across capacitor
+*      cap_mim_1f5fF          Subcircuit Model for 1.5fF/um2 MIM (*)-usable for Volt <=6V across capacitor
+*      cap_mim_1f0fF          Subcircuit Model for 1.0fF/um2 MIM (*)-usable for Volt <=20V across capacitor 
+*      cap_mim_2f0fF          Subcircuit Model for 2fF/um2 MIM      -usable for Volt <=6V across capacitor
 * 	
-*      nmoscap_3p3        Subcircuit Model for 3.3v inversion-mode  NMOS capacitor
-*      pmoscap_3p3	 	  Subcircuit Model for 3.3v inversion-mode  PMOS capacitor     
-*      nmoscap_6p0        Subcircuit Model for 6.0V inversion-mode  NMOS capacitor
-*      pmoscap_6p0	  	  Subcircuit Model for 6.0V inversion-mode  PMOS capacitor     
-*      nmoscap_3p3_b      Subcircuit Model for 3.3v NMOS in Nwell capacitor
-*      pmoscap_3p3_b	  Subcircuit Model for 3.3v PMOS in Pwell capacitor     
-*      nmoscap_6p0_b      Subcircuit Model for 6.0V NMOS in Nwell capacitor
-*      pmoscap_6p0_b	  Subcircuit Model for 6.0V PMOS in Pwell capacitor 
+*      cap_nmos_03v3        Subcircuit Model for 3.3v inversion-mode  NMOS capacitor
+*      cap_pmos_03v3	 	  Subcircuit Model for 3.3v inversion-mode  PMOS capacitor     
+*      cap_nmos_06v0        Subcircuit Model for 6.0V inversion-mode  NMOS capacitor
+*      cap_pmos_06v0	  	  Subcircuit Model for 6.0V inversion-mode  PMOS capacitor     
+*      cap_nmos_03v3_b      Subcircuit Model for 3.3v NMOS in Nwell capacitor
+*      cap_pmos_03v3_b	  Subcircuit Model for 3.3v PMOS in Pwell capacitor     
+*      cap_nmos_06v0_b      Subcircuit Model for 6.0V NMOS in Nwell capacitor
+*      cap_pmos_06v0_b	  Subcircuit Model for 6.0V PMOS in Pwell capacitor 
 *
 *      efuse    	      Subcircuit model for 6V/(5V) efuse
 ************************************************************************************************
 *
 .LIB typical
- .lib 'sm141064.ngspice' nmos_3p3_t
- .lib 'sm141064.ngspice' pmos_3p3_t
+ .lib 'sm141064.ngspice' nfet_03v3_t
+ .lib 'sm141064.ngspice' pfet_03v3_t
 *
  .param rsh_nplus_u_m=60
  .param rsh_pplus_u_m=185
- .param nmos_6p0_vsat = 1         
- .param nmos_6p0_vth0 = 0              
- .param nmos_6p0_xl = 0
- .param nmos_6p0_xw = 0
- .param nmos_6p0_tox = 0
- .param nmos_6p0_cgso = 1
- .param nmos_6p0_cgdo = 1
- .param nmos_6p0_nat_u0 = '0.070102'
- .param nmos_6p0_nat_vth0 = '-0.039'
- .param nmos_6p0_nat_xl = '0'
- .param nmos_6p0_nat_xw = '0'
- .param nmos_6p0_nat_tox = '1.52e-008'
- .param nmos_6p0_nat_cgso = '1e-010'
- .param nmos_6p0_nat_cgdo = '1e-010'
- .param pmos_6p0_dvth0 = 0            
- .param pmos_6p0_dxl = 0              
- .param pmos_6p0_dxw = 0              
- .param pmos_6p0_dtox = 0             
- .param pmos_6p0_dcgdo = 1            
- .param pmos_6p0_dcgso = 1            
+ .param nfet_06v0_vsat = 1         
+ .param nfet_06v0_vth0 = 0              
+ .param nfet_06v0_xl = 0
+ .param nfet_06v0_xw = 0
+ .param nfet_06v0_tox = 0
+ .param nfet_06v0_cgso = 1
+ .param nfet_06v0_cgdo = 1
+ .param nfet_06v0_nvt_u0 = '0.070102'
+ .param nfet_06v0_nvt_vth0 = '-0.039'
+ .param nfet_06v0_nvt_xl = '0'
+ .param nfet_06v0_nvt_xw = '0'
+ .param nfet_06v0_nvt_tox = '1.52e-008'
+ .param nfet_06v0_nvt_cgso = '1e-010'
+ .param nfet_06v0_nvt_cgdo = '1e-010'
+ .param pfet_06v0_dvth0 = 0            
+ .param pfet_06v0_dxl = 0              
+ .param pfet_06v0_dxw = 0              
+ .param pfet_06v0_dtox = 0             
+ .param pfet_06v0_dcgdo = 1            
+ .param pfet_06v0_dcgso = 1            
 
- .lib 'sm141064.ngspice' nmos_6p0_t
- .lib 'sm141064.ngspice' pmos_6p0_t
- .lib 'sm141064.ngspice' nmos_6p0_nat_t
+ .lib 'sm141064.ngspice' nfet_06v0_t
+ .lib 'sm141064.ngspice' pfet_06v0_t
+ .lib 'sm141064.ngspice' nfet_06v0_nvt_t
  .lib 'sm141064.ngspice' noise_corner
  .lib 'sm141064.ngspice' fets_mm
 .ENDL
 *
 *
 .LIB ff
- .lib 'sm141064.ngspice' nmos_3p3_f
- .lib 'sm141064.ngspice' pmos_3p3_f
+ .lib 'sm141064.ngspice' nfet_03v3_f
+ .lib 'sm141064.ngspice' pfet_03v3_f
 *
  .param rsh_nplus_u_m=45
  .param rsh_pplus_u_m=145
- .param nmos_6p0_vsat = 1.0846        
- .param nmos_6p0_vth0 = -0.1298       
- .param nmos_6p0_xl = -4.2E-8         
- .param nmos_6p0_xw = 5E-8            
- .param nmos_6p0_tox = -1E-9          
- .param nmos_6p0_cgso = 0.9           
- .param nmos_6p0_cgdo = 0.9      
- .param nmos_6p0_nat_u0 = '0.118'
- .param nmos_6p0_nat_vth0 = '-0.216'
- .param nmos_6p0_nat_xl = '-2e-7'
- .param nmos_6p0_nat_xw = '1e-7'
- .param nmos_6p0_nat_tox = '1.42e-008'
- .param nmos_6p0_nat_cgso = '9e-011'
- .param nmos_6p0_nat_cgdo = '9e-011'
- .param pmos_6p0_dvth0 = 0.1245       
- .param pmos_6p0_dxl = -4.65E-8       
- .param pmos_6p0_dxw = 5E-8           
- .param pmos_6p0_dtox = -1E-9         
- .param pmos_6p0_dcgdo = 0.9          
- .param pmos_6p0_dcgso = 0.9            
+ .param nfet_06v0_vsat = 1.0846        
+ .param nfet_06v0_vth0 = -0.1298       
+ .param nfet_06v0_xl = -4.2E-8         
+ .param nfet_06v0_xw = 5E-8            
+ .param nfet_06v0_tox = -1E-9          
+ .param nfet_06v0_cgso = 0.9           
+ .param nfet_06v0_cgdo = 0.9      
+ .param nfet_06v0_nvt_u0 = '0.118'
+ .param nfet_06v0_nvt_vth0 = '-0.216'
+ .param nfet_06v0_nvt_xl = '-2e-7'
+ .param nfet_06v0_nvt_xw = '1e-7'
+ .param nfet_06v0_nvt_tox = '1.42e-008'
+ .param nfet_06v0_nvt_cgso = '9e-011'
+ .param nfet_06v0_nvt_cgdo = '9e-011'
+ .param pfet_06v0_dvth0 = 0.1245       
+ .param pfet_06v0_dxl = -4.65E-8       
+ .param pfet_06v0_dxw = 5E-8           
+ .param pfet_06v0_dtox = -1E-9         
+ .param pfet_06v0_dcgdo = 0.9          
+ .param pfet_06v0_dcgso = 0.9            
 
- .lib 'sm141064.ngspice' nmos_6p0_t
- .lib 'sm141064.ngspice' pmos_6p0_t
- .lib 'sm141064.ngspice' nmos_6p0_nat_t
+ .lib 'sm141064.ngspice' nfet_06v0_t
+ .lib 'sm141064.ngspice' pfet_06v0_t
+ .lib 'sm141064.ngspice' nfet_06v0_nvt_t
  .lib 'sm141064.ngspice' noise_corner
  .lib 'sm141064.ngspice' fets_mm
 .ENDL
 *
 *
 .LIB ss
- .lib 'sm141064.ngspice' nmos_3p3_s
- .lib 'sm141064.ngspice' pmos_3p3_s
+ .lib 'sm141064.ngspice' nfet_03v3_s
+ .lib 'sm141064.ngspice' pfet_03v3_s
 *
  .param rsh_nplus_u_m=75
  .param rsh_pplus_u_m=225
- .param nmos_6p0_vsat = 0.899         
- .param nmos_6p0_vth0 = 0.1193        
- .param nmos_6p0_xl = 7E-8            
- .param nmos_6p0_xw = -5E-8           
- .param nmos_6p0_tox = 1E-9           
- .param nmos_6p0_cgso = 1.1           
- .param nmos_6p0_cgdo = 1.1  
- .param nmos_6p0_nat_u0 = '0.046'
- .param nmos_6p0_nat_vth0 = '0.1417'
- .param nmos_6p0_nat_xl = '2e-7'
- .param nmos_6p0_nat_xw = '-1e-7'
- .param nmos_6p0_nat_tox = '1.62e-008'
- .param nmos_6p0_nat_cgso = '1.1e-010'
- .param nmos_6p0_nat_cgdo = '1.1e-010' 
- .param pmos_6p0_dvth0 = -0.1225      
- .param pmos_6p0_dxl = 6.9E-8       
- .param pmos_6p0_dxw = -5E-8          
- .param pmos_6p0_dtox = 1E-9          
- .param pmos_6p0_dcgdo = 1.1          
- .param pmos_6p0_dcgso = 1.1           
+ .param nfet_06v0_vsat = 0.899         
+ .param nfet_06v0_vth0 = 0.1193        
+ .param nfet_06v0_xl = 7E-8            
+ .param nfet_06v0_xw = -5E-8           
+ .param nfet_06v0_tox = 1E-9           
+ .param nfet_06v0_cgso = 1.1           
+ .param nfet_06v0_cgdo = 1.1  
+ .param nfet_06v0_nvt_u0 = '0.046'
+ .param nfet_06v0_nvt_vth0 = '0.1417'
+ .param nfet_06v0_nvt_xl = '2e-7'
+ .param nfet_06v0_nvt_xw = '-1e-7'
+ .param nfet_06v0_nvt_tox = '1.62e-008'
+ .param nfet_06v0_nvt_cgso = '1.1e-010'
+ .param nfet_06v0_nvt_cgdo = '1.1e-010' 
+ .param pfet_06v0_dvth0 = -0.1225      
+ .param pfet_06v0_dxl = 6.9E-8       
+ .param pfet_06v0_dxw = -5E-8          
+ .param pfet_06v0_dtox = 1E-9          
+ .param pfet_06v0_dcgdo = 1.1          
+ .param pfet_06v0_dcgso = 1.1           
 
- .lib 'sm141064.ngspice' nmos_6p0_t
- .lib 'sm141064.ngspice' pmos_6p0_t
- .lib 'sm141064.ngspice' nmos_6p0_nat_t
+ .lib 'sm141064.ngspice' nfet_06v0_t
+ .lib 'sm141064.ngspice' pfet_06v0_t
+ .lib 'sm141064.ngspice' nfet_06v0_nvt_t
  .lib 'sm141064.ngspice' noise_corner
  .lib 'sm141064.ngspice' fets_mm
 .ENDL
 *
 *
 .LIB fs
- .lib 'sm141064.ngspice' nmos_3p3_fs
- .lib 'sm141064.ngspice' pmos_3p3_fs
+ .lib 'sm141064.ngspice' nfet_03v3_fs
+ .lib 'sm141064.ngspice' pfet_03v3_fs
 *
  .param rsh_nplus_u_m=48
  .param rsh_pplus_u_m=219
- .param nmos_6p0_vsat = '0.0846*0.67+1'        
- .param nmos_6p0_vth0 = '-0.1298*0.75'       
- .param nmos_6p0_xl = '-4.2E-8*0.67'         
- .param nmos_6p0_xw = '5E-8*0.67'            
- .param nmos_6p0_tox = '-1E-9*0.75'          
- .param nmos_6p0_cgso = 0.93           
- .param nmos_6p0_cgdo = 0.93     
- .param nmos_6p0_nat_u0 = '0.102034'
- .param nmos_6p0_nat_vth0 = '-0.157'
- .param nmos_6p0_nat_xl = '-1.33e-7'
- .param nmos_6p0_nat_xw = '6.7e-8'
- .param nmos_6p0_nat_tox = '1.453e-008'
- .param nmos_6p0_nat_cgso = '9.33e-011'
- .param nmos_6p0_nat_cgdo = '9.33e-011' 
- .param pmos_6p0_dvth0 = -0.0829      
- .param pmos_6p0_dxl = 4.1E-8         
- .param pmos_6p0_dxw = -3.35E-8       
- .param pmos_6p0_dtox = 6.7E-10       
- .param pmos_6p0_dcgdo = 1.07         
- .param pmos_6p0_dcgso = 1.07            
+ .param nfet_06v0_vsat = '0.0846*0.67+1'        
+ .param nfet_06v0_vth0 = '-0.1298*0.75'       
+ .param nfet_06v0_xl = '-4.2E-8*0.67'         
+ .param nfet_06v0_xw = '5E-8*0.67'            
+ .param nfet_06v0_tox = '-1E-9*0.75'          
+ .param nfet_06v0_cgso = 0.93           
+ .param nfet_06v0_cgdo = 0.93     
+ .param nfet_06v0_nvt_u0 = '0.102034'
+ .param nfet_06v0_nvt_vth0 = '-0.157'
+ .param nfet_06v0_nvt_xl = '-1.33e-7'
+ .param nfet_06v0_nvt_xw = '6.7e-8'
+ .param nfet_06v0_nvt_tox = '1.453e-008'
+ .param nfet_06v0_nvt_cgso = '9.33e-011'
+ .param nfet_06v0_nvt_cgdo = '9.33e-011' 
+ .param pfet_06v0_dvth0 = -0.0829      
+ .param pfet_06v0_dxl = 4.1E-8         
+ .param pfet_06v0_dxw = -3.35E-8       
+ .param pfet_06v0_dtox = 6.7E-10       
+ .param pfet_06v0_dcgdo = 1.07         
+ .param pfet_06v0_dcgso = 1.07            
 
- .lib 'sm141064.ngspice' nmos_6p0_t
- .lib 'sm141064.ngspice' pmos_6p0_t
- .lib 'sm141064.ngspice' nmos_6p0_nat_t
+ .lib 'sm141064.ngspice' nfet_06v0_t
+ .lib 'sm141064.ngspice' pfet_06v0_t
+ .lib 'sm141064.ngspice' nfet_06v0_nvt_t
  .lib 'sm141064.ngspice' noise_corner
  .lib 'sm141064.ngspice' fets_mm
 .ENDL
 *
 *
 .LIB sf
- .lib 'sm141064.ngspice' nmos_3p3_sf
- .lib 'sm141064.ngspice' pmos_3p3_sf
+ .lib 'sm141064.ngspice' nfet_03v3_sf
+ .lib 'sm141064.ngspice' pfet_03v3_sf
 *
  .param rsh_nplus_u_m=72
  .param rsh_pplus_u_m=150
- .param nmos_6p0_vsat = '1-(1-0.899)*0.67'         
- .param nmos_6p0_vth0 = '0.1193*0.75'        
- .param nmos_6p0_xl = '7E-8*0.67'            
- .param nmos_6p0_xw = '-5E-8*0.67'           
- .param nmos_6p0_tox = '1E-9*0.75'           
- .param nmos_6p0_cgso = 1.07          
- .param nmos_6p0_cgdo = 1.07    
- .param nmos_6p0_nat_u0 = '0.054034'
- .param nmos_6p0_nat_vth0 = '0.08147'
- .param nmos_6p0_nat_xl = '1.33e-7'
- .param nmos_6p0_nat_xw = '-6.7e-8'
- .param nmos_6p0_nat_tox = '1.587e-008'
- .param nmos_6p0_nat_cgso = '1.067e-010'
- .param nmos_6p0_nat_cgdo = '1.067e-010'
- .param pmos_6p0_dvth0 = 0.0827       
- .param pmos_6p0_dxl = -3.22E-8       
- .param pmos_6p0_dxw = 3.35E-8        
- .param pmos_6p0_dtox = -6.7E-10      
- .param pmos_6p0_dcgdo = 0.93         
- .param pmos_6p0_dcgso = 0.93           
+ .param nfet_06v0_vsat = '1-(1-0.899)*0.67'         
+ .param nfet_06v0_vth0 = '0.1193*0.75'        
+ .param nfet_06v0_xl = '7E-8*0.67'            
+ .param nfet_06v0_xw = '-5E-8*0.67'           
+ .param nfet_06v0_tox = '1E-9*0.75'           
+ .param nfet_06v0_cgso = 1.07          
+ .param nfet_06v0_cgdo = 1.07    
+ .param nfet_06v0_nvt_u0 = '0.054034'
+ .param nfet_06v0_nvt_vth0 = '0.08147'
+ .param nfet_06v0_nvt_xl = '1.33e-7'
+ .param nfet_06v0_nvt_xw = '-6.7e-8'
+ .param nfet_06v0_nvt_tox = '1.587e-008'
+ .param nfet_06v0_nvt_cgso = '1.067e-010'
+ .param nfet_06v0_nvt_cgdo = '1.067e-010'
+ .param pfet_06v0_dvth0 = 0.0827       
+ .param pfet_06v0_dxl = -3.22E-8       
+ .param pfet_06v0_dxw = 3.35E-8        
+ .param pfet_06v0_dtox = -6.7E-10      
+ .param pfet_06v0_dcgdo = 0.93         
+ .param pfet_06v0_dcgso = 0.93           
 
- .lib 'sm141064.ngspice' nmos_6p0_t
- .lib 'sm141064.ngspice' pmos_6p0_t
- .lib 'sm141064.ngspice' nmos_6p0_nat_t
+ .lib 'sm141064.ngspice' nfet_06v0_t
+ .lib 'sm141064.ngspice' pfet_06v0_t
+ .lib 'sm141064.ngspice' nfet_06v0_nvt_t
  .lib 'sm141064.ngspice' noise_corner
  .lib 'sm141064.ngspice' fets_mm
 .ENDL
@@ -489,7 +489,7 @@
 .param mc_c_cox_1p5fF=0
 .param mc_c_cox_2p0fF=0
 
-.lib 'sm141064.ngspice' mim_cap
+.lib 'sm141064_mim.ngspice' cap_mim_new
 .ENDL
 *
 .LIB mimcap_ss
@@ -500,7 +500,7 @@
 .param mc_c_cox_1p5fF=0
 .param mc_c_cox_2p0fF=0
 
-.lib 'sm141064.ngspice' mim_cap
+.lib 'sm141064_mim.ngspice' cap_mim_new
 .ENDL
 *
 .LIB mimcap_ff
@@ -512,48 +512,48 @@
 .param mc_c_cox_1p5fF=0
 .param mc_c_cox_2p0fF=0
 
-.lib 'sm141064.ngspice' mim_cap
+.lib 'sm141064_mim.ngspice' cap_mim_new
 .ENDL
 ****************************************************
 *
 .lib moscap_typical
 .param 
- + nmoscap_3p3_corner=1
- + pmoscap_3p3_corner=1
- + nmoscap_6p0_corner=1
- + pmoscap_6p0_corner=1
- + nmoscap_3p3_b_corner=1
- + pmoscap_3p3_b_corner=1
- + nmoscap_6p0_b_corner=1
- + pmoscap_6p0_b_corner=1
+ + cap_nmos_03v3_corner=1
+ + cap_pmos_03v3_corner=1
+ + cap_nmos_06v0_corner=1
+ + cap_pmos_06v0_corner=1
+ + cap_nmos_03v3_b_corner=1
+ + cap_pmos_03v3_b_corner=1
+ + cap_nmos_06v0_b_corner=1
+ + cap_pmos_06v0_b_corner=1
   
 .lib 'sm141064.ngspice' moscap
 .ENDL
 *
 .lib moscap_ff
 .param 
- + nmoscap_3p3_corner=0.9
- + pmoscap_3p3_corner=0.9
- + nmoscap_6p0_corner=0.9
- + pmoscap_6p0_corner=0.9
- + nmoscap_3p3_b_corner=0.9
- + pmoscap_3p3_b_corner=0.9
- + nmoscap_6p0_b_corner=0.9
- + pmoscap_6p0_b_corner=0.9
+ + cap_nmos_03v3_corner=0.9
+ + cap_pmos_03v3_corner=0.9
+ + cap_nmos_06v0_corner=0.9
+ + cap_pmos_06v0_corner=0.9
+ + cap_nmos_03v3_b_corner=0.9
+ + cap_pmos_03v3_b_corner=0.9
+ + cap_nmos_06v0_b_corner=0.9
+ + cap_pmos_06v0_b_corner=0.9
 
 .lib 'sm141064.ngspice' moscap
 .ENDL
 *
 .lib moscap_ss
 .param 
- + nmoscap_3p3_corner=1.1
- + pmoscap_3p3_corner=1.1
- + nmoscap_6p0_corner=1.1
- + pmoscap_6p0_corner=1.1
- + nmoscap_3p3_b_corner=1.1
- + pmoscap_3p3_b_corner=1.1
- + nmoscap_6p0_b_corner=1.1
- + pmoscap_6p0_b_corner=1.1
+ + cap_nmos_03v3_corner=1.1
+ + cap_pmos_03v3_corner=1.1
+ + cap_nmos_06v0_corner=1.1
+ + cap_pmos_06v0_corner=1.1
+ + cap_nmos_03v3_b_corner=1.1
+ + cap_pmos_03v3_b_corner=1.1
+ + cap_nmos_06v0_b_corner=1.1
+ + cap_pmos_06v0_b_corner=1.1
 
 .lib 'sm141064.ngspice' moscap
 .ENDL
@@ -611,82 +611,82 @@
  
  ****** 3.3V devices monte carlo parameters ******
  .param
- + nmos_3p3_sig_vth1 = '(5e-3*mc_sig_vth+30e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
- + nmos_3p3_sig_vth2 = '(5e-3*mc_sig_vth+25e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
- + nmos_3p3_sig_vth3 = '(5e-3*mc_sig_vth+15e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
- + nmos_3p3_tox = '8e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeN)*sw_stat_global*mc_skew'
- + nmos_3p3_xl = '(7e-9*mc_xl+6e-9*mc_xlN)*sw_stat_global*mc_skew'
- + nmos_3p3_xw = '(7e-9*mc_xw+3e-9*mc_xwN)*sw_stat_global*mc_skew'
- + nmos_3p3_xj = '1e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjN)*sw_stat_global*mc_skew'
- + nmos_3p3_rdsw = '530 * (1+0.15* mc_rdswN*sw_stat_global*mc_skew)'
- + nmos_3p3_vth0_0 = '0.70837662 + nmos_3p3_sig_vth1'
- + nmos_3p3_vth0_1 = '0.67781184 + nmos_3p3_sig_vth1'
- + nmos_3p3_vth0_2 = '0.66097097 + nmos_3p3_sig_vth2'
- + nmos_3p3_vth0_3 = '0.66064857 + nmos_3p3_sig_vth2'
- + nmos_3p3_vth0_4 = '0.72356597 + nmos_3p3_sig_vth1'
- + nmos_3p3_vth0_5 = '0.67504024 + nmos_3p3_sig_vth2'
- + nmos_3p3_vth0_6 = '0.64923469 + nmos_3p3_sig_vth2'
- + nmos_3p3_vth0_7 = '0.65055971 + nmos_3p3_sig_vth3'
- + nmos_3p3_vth0_8 = '0.75419347 + nmos_3p3_sig_vth2'
- + nmos_3p3_vth0_9 = '0.66260505 + nmos_3p3_sig_vth2'
- + nmos_3p3_vth0_10 = '0.64815901 + nmos_3p3_sig_vth3'
- + nmos_3p3_vth0_11 = '0.64889718 + nmos_3p3_sig_vth3'
- + nmos_3p3_vth0_12 = '0.74840818 + nmos_3p3_sig_vth2'
- + nmos_3p3_vth0_13 = '0.66297571 + nmos_3p3_sig_vth3'
- + nmos_3p3_vth0_14 = '0.64787864 + nmos_3p3_sig_vth3'
- + nmos_3p3_vth0_15 = '0.64857 + nmos_3p3_sig_vth3'
+ + nfet_03v3_sig_vth1 = '(5e-3*mc_sig_vth+30e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
+ + nfet_03v3_sig_vth2 = '(5e-3*mc_sig_vth+25e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
+ + nfet_03v3_sig_vth3 = '(5e-3*mc_sig_vth+15e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
+ + nfet_03v3_tox = '8e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeN)*sw_stat_global*mc_skew'
+ + nfet_03v3_xl = '(7e-9*mc_xl+6e-9*mc_xlN)*sw_stat_global*mc_skew'
+ + nfet_03v3_xw = '(7e-9*mc_xw+3e-9*mc_xwN)*sw_stat_global*mc_skew'
+ + nfet_03v3_xj = '1e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjN)*sw_stat_global*mc_skew'
+ + nfet_03v3_rdsw = '530 * (1+0.15* mc_rdswN*sw_stat_global*mc_skew)'
+ + nfet_03v3_vth0_0 = '0.70837662 + nfet_03v3_sig_vth1'
+ + nfet_03v3_vth0_1 = '0.67781184 + nfet_03v3_sig_vth1'
+ + nfet_03v3_vth0_2 = '0.66097097 + nfet_03v3_sig_vth2'
+ + nfet_03v3_vth0_3 = '0.66064857 + nfet_03v3_sig_vth2'
+ + nfet_03v3_vth0_4 = '0.72356597 + nfet_03v3_sig_vth1'
+ + nfet_03v3_vth0_5 = '0.67504024 + nfet_03v3_sig_vth2'
+ + nfet_03v3_vth0_6 = '0.64923469 + nfet_03v3_sig_vth2'
+ + nfet_03v3_vth0_7 = '0.65055971 + nfet_03v3_sig_vth3'
+ + nfet_03v3_vth0_8 = '0.75419347 + nfet_03v3_sig_vth2'
+ + nfet_03v3_vth0_9 = '0.66260505 + nfet_03v3_sig_vth2'
+ + nfet_03v3_vth0_10 = '0.64815901 + nfet_03v3_sig_vth3'
+ + nfet_03v3_vth0_11 = '0.64889718 + nfet_03v3_sig_vth3'
+ + nfet_03v3_vth0_12 = '0.74840818 + nfet_03v3_sig_vth2'
+ + nfet_03v3_vth0_13 = '0.66297571 + nfet_03v3_sig_vth3'
+ + nfet_03v3_vth0_14 = '0.64787864 + nfet_03v3_sig_vth3'
+ + nfet_03v3_vth0_15 = '0.64857 + nfet_03v3_sig_vth3'
  
   .param
- + pmos_3p3_sig_vth1 = '(-5e-3*mc_sig_vth-38e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
- + pmos_3p3_sig_vth2 = '(-5e-3*mc_sig_vth-30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
- + pmos_3p3_sig_vth3 = '(-5e-3*mc_sig_vth-18e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
- + pmos_3p3_tox = '7.9e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeP)*sw_stat_global*mc_skew'
- + pmos_3p3_xl = '(7e-9*mc_xl+4e-9*mc_xlP)*sw_stat_global*mc_skew'
- + pmos_3p3_xw = '(7e-9*mc_xw+3e-9*mc_xwP)*sw_stat_global*mc_skew'
- + pmos_3p3_xj = '1.0e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjP)*sw_stat_global*mc_skew'
- + pmos_3p3_rdsw = '466 * (1+0.15*mc_rdswP*sw_stat_global*mc_skew)'
- + pmos_3p3_vth0_0 = '-0.7506174 + pmos_3p3_sig_vth1'
- + pmos_3p3_vth0_1 = '-0.78216327 + pmos_3p3_sig_vth1'
- + pmos_3p3_vth0_2 = '-0.76745877 + pmos_3p3_sig_vth2'
- + pmos_3p3_vth0_3 = '-0.76841429 + pmos_3p3_sig_vth2'
- + pmos_3p3_vth0_4 = '-0.7710094 + pmos_3p3_sig_vth1'
- + pmos_3p3_vth0_5 = '-0.77464237 + pmos_3p3_sig_vth2'
- + pmos_3p3_vth0_6 = '-0.77376777 + pmos_3p3_sig_vth2'
- + pmos_3p3_vth0_7 = '-0.77390514 + pmos_3p3_sig_vth3'
- + pmos_3p3_vth0_8 = '-0.76226585 + pmos_3p3_sig_vth2'
- + pmos_3p3_vth0_9 = '-0.76552347 + pmos_3p3_sig_vth2'
- + pmos_3p3_vth0_10 = '-0.7677531 + pmos_3p3_sig_vth3'
- + pmos_3p3_vth0_11 = '-0.7682 + pmos_3p3_sig_vth3'
- + pmos_3p3_vth0_12 = '-0.76184364 + pmos_3p3_sig_vth2'
- + pmos_3p3_vth0_13 = '-0.76642857 + pmos_3p3_sig_vth3'
- + pmos_3p3_vth0_14 = '-0.76779091 + pmos_3p3_sig_vth3'
- + pmos_3p3_vth0_15 = '-0.7682 + pmos_3p3_sig_vth3'
+ + pfet_03v3_sig_vth1 = '(-5e-3*mc_sig_vth-38e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
+ + pfet_03v3_sig_vth2 = '(-5e-3*mc_sig_vth-30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
+ + pfet_03v3_sig_vth3 = '(-5e-3*mc_sig_vth-18e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
+ + pfet_03v3_tox = '7.9e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeP)*sw_stat_global*mc_skew'
+ + pfet_03v3_xl = '(7e-9*mc_xl+4e-9*mc_xlP)*sw_stat_global*mc_skew'
+ + pfet_03v3_xw = '(7e-9*mc_xw+3e-9*mc_xwP)*sw_stat_global*mc_skew'
+ + pfet_03v3_xj = '1.0e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjP)*sw_stat_global*mc_skew'
+ + pfet_03v3_rdsw = '466 * (1+0.15*mc_rdswP*sw_stat_global*mc_skew)'
+ + pfet_03v3_vth0_0 = '-0.7506174 + pfet_03v3_sig_vth1'
+ + pfet_03v3_vth0_1 = '-0.78216327 + pfet_03v3_sig_vth1'
+ + pfet_03v3_vth0_2 = '-0.76745877 + pfet_03v3_sig_vth2'
+ + pfet_03v3_vth0_3 = '-0.76841429 + pfet_03v3_sig_vth2'
+ + pfet_03v3_vth0_4 = '-0.7710094 + pfet_03v3_sig_vth1'
+ + pfet_03v3_vth0_5 = '-0.77464237 + pfet_03v3_sig_vth2'
+ + pfet_03v3_vth0_6 = '-0.77376777 + pfet_03v3_sig_vth2'
+ + pfet_03v3_vth0_7 = '-0.77390514 + pfet_03v3_sig_vth3'
+ + pfet_03v3_vth0_8 = '-0.76226585 + pfet_03v3_sig_vth2'
+ + pfet_03v3_vth0_9 = '-0.76552347 + pfet_03v3_sig_vth2'
+ + pfet_03v3_vth0_10 = '-0.7677531 + pfet_03v3_sig_vth3'
+ + pfet_03v3_vth0_11 = '-0.7682 + pfet_03v3_sig_vth3'
+ + pfet_03v3_vth0_12 = '-0.76184364 + pfet_03v3_sig_vth2'
+ + pfet_03v3_vth0_13 = '-0.76642857 + pfet_03v3_sig_vth3'
+ + pfet_03v3_vth0_14 = '-0.76779091 + pfet_03v3_sig_vth3'
+ + pfet_03v3_vth0_15 = '-0.7682 + pfet_03v3_sig_vth3'
  
  ****** 6.0V devices monte carlo parameters ******
  .param
- + nmos_6p0_vsat = '(1-0.063* mc_rdswN*sw_stat_global*mc_skew)'         
- + nmos_6p0_vth0 = '(8e-3*mc_sig_vth+28e-3*mc_sig_vthN)*sw_stat_global*mc_skew'              
- + nmos_6p0_xl = '(2e-8*mc_xl+0*mc_xlN)*sw_stat_global*mc_skew'
- + nmos_6p0_xw = '(1.5e-8*mc_xw+9e-9*mc_xwN)*sw_stat_global*mc_skew'
- + nmos_6p0_tox = '(4e-10*mc_toxe+1.3e-10*mc_toxeN)*sw_stat_global*mc_skew'
- + nmos_6p0_cgso = 1
- + nmos_6p0_cgdo = 1
+ + nfet_06v0_vsat = '(1-0.063* mc_rdswN*sw_stat_global*mc_skew)'         
+ + nfet_06v0_vth0 = '(8e-3*mc_sig_vth+28e-3*mc_sig_vthN)*sw_stat_global*mc_skew'              
+ + nfet_06v0_xl = '(2e-8*mc_xl+0*mc_xlN)*sw_stat_global*mc_skew'
+ + nfet_06v0_xw = '(1.5e-8*mc_xw+9e-9*mc_xwN)*sw_stat_global*mc_skew'
+ + nfet_06v0_tox = '(4e-10*mc_toxe+1.3e-10*mc_toxeN)*sw_stat_global*mc_skew'
+ + nfet_06v0_cgso = 1
+ + nfet_06v0_cgdo = 1
  
  .param
- + pmos_6p0_vth0 = '-0.8978 + (8e-3*mc_sig_vth+30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
- + pmos_6p0_tox = '156e-010 + (4e-10*mc_toxe+1e-10*mc_toxeP)*sw_stat_global*mc_skew'
- + pmos_6p0_xl = '0 + (2e-8*mc_xl+2e-9*mc_xlP)*sw_stat_global*mc_skew'
- + pmos_6p0_xw = '0 + (1.5e-8*mc_xw+9e-9*mc_xwP)*sw_stat_global*mc_skew'
- + pmos_6p0_xj = '1.5e-7 + (0.3e-9*mc_xj+1e-8*mc_xjP)*sw_stat_global*mc_skew'
- + pmos_6p0_rdsw = '1426 * (1+0.2* mc_rdswP*sw_stat_global*mc_skew)'
+ + pfet_06v0_vth0 = '-0.8978 + (8e-3*mc_sig_vth+30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
+ + pfet_06v0_tox = '156e-010 + (4e-10*mc_toxe+1e-10*mc_toxeP)*sw_stat_global*mc_skew'
+ + pfet_06v0_xl = '0 + (2e-8*mc_xl+2e-9*mc_xlP)*sw_stat_global*mc_skew'
+ + pfet_06v0_xw = '0 + (1.5e-8*mc_xw+9e-9*mc_xwP)*sw_stat_global*mc_skew'
+ + pfet_06v0_xj = '1.5e-7 + (0.3e-9*mc_xj+1e-8*mc_xjP)*sw_stat_global*mc_skew'
+ + pfet_06v0_rdsw = '1426 * (1+0.2* mc_rdswP*sw_stat_global*mc_skew)'
 
  .param
- + nmos_6p0_nat_vth0 = '-0.039 + (8e-3*mc_sig_vth+60e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
- + nmos_6p0_nat_tox = '152e-010 + (4e-10*mc_toxe+6e-10*mc_toxeN)*sw_stat_global*mc_skew'
- + nmos_6p0_nat_xl = '0 + (2e-8*mc_xl+8e-8*mc_xlN)*sw_stat_global*mc_skew'
- + nmos_6p0_nat_xw = '0 + (1.5e-8*mc_xw+8e-8*mc_xwN)*sw_stat_global*mc_skew'
- + nmos_6p0_nat_xj = '1.5e-7 + (0.3e-9*mc_xj+2e-8*mc_xjN)*sw_stat_global*mc_skew'
- + nmos_6p0_nat_rdsw = '3480 * (1+0.2* mc_rdswN*sw_stat_global*mc_skew)'
+ + nfet_06v0_nvt_vth0 = '-0.039 + (8e-3*mc_sig_vth+60e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
+ + nfet_06v0_nvt_tox = '152e-010 + (4e-10*mc_toxe+6e-10*mc_toxeN)*sw_stat_global*mc_skew'
+ + nfet_06v0_nvt_xl = '0 + (2e-8*mc_xl+8e-8*mc_xlN)*sw_stat_global*mc_skew'
+ + nfet_06v0_nvt_xw = '0 + (1.5e-8*mc_xw+8e-8*mc_xwN)*sw_stat_global*mc_skew'
+ + nfet_06v0_nvt_xj = '1.5e-7 + (0.3e-9*mc_xj+2e-8*mc_xjN)*sw_stat_global*mc_skew'
+ + nfet_06v0_nvt_rdsw = '3480 * (1+0.2* mc_rdswN*sw_stat_global*mc_skew)'
 
 .param
 + rsh_nplus2_u=60
@@ -696,11 +696,11 @@
 + rsh_pplus_u_m = 'rsh_pplus2_u*(1+(mc_rsh_pplus_u/(rsh_pplus2_u))*res_mc_skew*sw_stat_global)'
 
  .lib 'sm141064.ngspice' fets_mm
- .lib 'sm141064.ngspice' nmos_3p3_stat 
- .lib 'sm141064.ngspice' pmos_3p3_stat
- .lib 'sm141064.ngspice' nmos_6p0_t 
- .lib 'sm141064.ngspice' pmos_6p0_stat
- .lib 'sm141064.ngspice' nmos_6p0_nat_stat 
+ .lib 'sm141064.ngspice' nfet_03v3_stat 
+ .lib 'sm141064.ngspice' pfet_03v3_stat
+ .lib 'sm141064.ngspice' nfet_06v0_t 
+ .lib 'sm141064.ngspice' pfet_06v0_stat
+ .lib 'sm141064.ngspice' nfet_06v0_nvt_stat 
  .lib 'sm141064.ngspice' noise_corner
 
 .ENDL
@@ -708,25 +708,25 @@
 *
 .LIB noise_corner
  .param
- +nmos_3p3_noia='(fnoicor==0)*3.2e+041 + (fnoicor==1)*3.5e+042' 
- +nmos_3p3_noib='(fnoicor==0)*1.2e+020 + (fnoicor==1)*1.2e+020' 
- +nmos_3p3_noic='(fnoicor==0)*6.0e+008 + (fnoicor==1)*6.0e+008'
+ +nfet_03v3_noia='(fnoicor==0)*3.2e+041 + (fnoicor==1)*3.5e+042' 
+ +nfet_03v3_noib='(fnoicor==0)*1.2e+020 + (fnoicor==1)*1.2e+020' 
+ +nfet_03v3_noic='(fnoicor==0)*6.0e+008 + (fnoicor==1)*6.0e+008'
 
- +pmos_3p3_noia='(fnoicor==0)*3.2e+041 + (fnoicor==1)*4.0e+042' 
- +pmos_3p3_noib='(fnoicor==0)*1.8e+020 + (fnoicor==1)*1.8e+020' 
- +pmos_3p3_noic='(fnoicor==0)*3.0e+009 + (fnoicor==1)*6.0e+009'
+ +pfet_03v3_noia='(fnoicor==0)*3.2e+041 + (fnoicor==1)*4.0e+042' 
+ +pfet_03v3_noib='(fnoicor==0)*1.8e+020 + (fnoicor==1)*1.8e+020' 
+ +pfet_03v3_noic='(fnoicor==0)*3.0e+009 + (fnoicor==1)*6.0e+009'
 
- +nmos_6p0_noia='(fnoicor==0)*1.998e+041 + (fnoicor==1)*8e+041' 
- +nmos_6p0_noib='(fnoicor==0)*1e+025 + (fnoicor==1)*4e+025' 
- +nmos_6p0_noic='(fnoicor==0)*5e+008 + (fnoicor==1)*2e+009'
+ +nfet_06v0_noia='(fnoicor==0)*1.998e+041 + (fnoicor==1)*8e+041' 
+ +nfet_06v0_noib='(fnoicor==0)*1e+025 + (fnoicor==1)*4e+025' 
+ +nfet_06v0_noic='(fnoicor==0)*5e+008 + (fnoicor==1)*2e+009'
 
- +pmos_6p0_noia='(fnoicor==0)*6e+040 + (fnoicor==1)*2e+043' 
- +pmos_6p0_noib='(fnoicor==0)*1.5945e+025 + (fnoicor==1)*1.5945e+025' 
- +pmos_6p0_noic='(fnoicor==0)*1.0499e+009 + (fnoicor==1)*1.0499e+009'
+ +pfet_06v0_noia='(fnoicor==0)*6e+040 + (fnoicor==1)*2e+043' 
+ +pfet_06v0_noib='(fnoicor==0)*1.5945e+025 + (fnoicor==1)*1.5945e+025' 
+ +pfet_06v0_noic='(fnoicor==0)*1.0499e+009 + (fnoicor==1)*1.0499e+009'
 
- +nmos_6p0_nat_noia='(fnoicor==0)*5.5e+040 + (fnoicor==1)*1e+041' 
- +nmos_6p0_nat_noib='(fnoicor==0)*2.5e+025 + (fnoicor==1)*9.5e+025' 
- +nmos_6p0_nat_noic='(fnoicor==0)*1e+007 + (fnoicor==1)*2e+007'
+ +nfet_06v0_nvt_noia='(fnoicor==0)*5.5e+040 + (fnoicor==1)*1e+041' 
+ +nfet_06v0_nvt_noib='(fnoicor==0)*2.5e+025 + (fnoicor==1)*9.5e+025' 
+ +nfet_06v0_nvt_noic='(fnoicor==0)*1e+007 + (fnoicor==1)*2e+007'
 
 .ENDL
 *
@@ -735,10 +735,10 @@
 * 3.3V NMOS Models
 ***************************************************************************************************
 *
-.lib nmos_3p3_t
+.lib nfet_03v3_t
 
 
-.subckt nmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt nfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.007148  
@@ -761,12 +761,12 @@ xr1 d d1 b nplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab'
 xr2 s s1 b nplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
 
 
-m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b nfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  nmos_3p3.0  nmos
+.model  nfet_03v3.0  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -978,9 +978,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -1010,7 +1010,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.1  nmos
+.model  nfet_03v3.1  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -1221,9 +1221,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -1253,7 +1253,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.2  nmos
+.model  nfet_03v3.2  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -1456,9 +1456,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -1488,7 +1488,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.3  nmos
+.model  nfet_03v3.3  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -1657,9 +1657,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -1689,7 +1689,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.4  nmos
+.model  nfet_03v3.4  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -1896,9 +1896,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -1928,7 +1928,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.5  nmos
+.model  nfet_03v3.5  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -2139,9 +2139,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -2171,7 +2171,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.6  nmos
+.model  nfet_03v3.6  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -2377,9 +2377,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -2409,7 +2409,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.7  nmos
+.model  nfet_03v3.7  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -2574,9 +2574,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -2606,7 +2606,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.8  nmos
+.model  nfet_03v3.8  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -2820,9 +2820,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -2852,7 +2852,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.9  nmos
+.model  nfet_03v3.9  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -3055,9 +3055,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -3087,7 +3087,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.10  nmos
+.model  nfet_03v3.10  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -3300,9 +3300,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -3332,7 +3332,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.11  nmos
+.model  nfet_03v3.11  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -3500,9 +3500,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -3532,7 +3532,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.12  nmos
+.model  nfet_03v3.12  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -3710,9 +3710,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -3742,7 +3742,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.13  nmos
+.model  nfet_03v3.13  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -3912,9 +3912,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -3944,7 +3944,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.14  nmos
+.model  nfet_03v3.14  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -4120,9 +4120,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -4152,7 +4152,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.15  nmos
+.model  nfet_03v3.15  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -4305,9 +4305,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -4383,13 +4383,13 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 *-------------------
 .ends nplus_u_m1
 
-.endl nmos_3p3_t
+.endl nfet_03v3_t
 *
 *
-.lib nmos_3p3_f
+.lib nfet_03v3_f
 
 
-.subckt nmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt nfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.007148  
@@ -4409,12 +4409,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 + mis_vth=agauss(0,var_vth,1)
 xr1 d d1 b nplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b nplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b nfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  nmos_3p3.0  nmos
+.model  nfet_03v3.0  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -4626,9 +4626,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -4658,7 +4658,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.1  nmos
+.model  nfet_03v3.1  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -4869,9 +4869,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -4901,7 +4901,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.2  nmos
+.model  nfet_03v3.2  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -5104,9 +5104,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -5136,7 +5136,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.3  nmos
+.model  nfet_03v3.3  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -5305,9 +5305,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -5337,7 +5337,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.4  nmos
+.model  nfet_03v3.4  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -5544,9 +5544,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -5576,7 +5576,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.5  nmos
+.model  nfet_03v3.5  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -5787,9 +5787,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -5819,7 +5819,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.6  nmos
+.model  nfet_03v3.6  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -6025,9 +6025,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -6057,7 +6057,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.7  nmos
+.model  nfet_03v3.7  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -6222,9 +6222,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -6254,7 +6254,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.8  nmos
+.model  nfet_03v3.8  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -6468,9 +6468,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -6500,7 +6500,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.9  nmos
+.model  nfet_03v3.9  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -6703,9 +6703,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -6735,7 +6735,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.10  nmos
+.model  nfet_03v3.10  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -6948,9 +6948,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -6980,7 +6980,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.11  nmos
+.model  nfet_03v3.11  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -7148,9 +7148,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -7180,7 +7180,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.12  nmos
+.model  nfet_03v3.12  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -7358,9 +7358,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -7390,7 +7390,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.13  nmos
+.model  nfet_03v3.13  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -7560,9 +7560,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -7592,7 +7592,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.14  nmos
+.model  nfet_03v3.14  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -7768,9 +7768,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -7800,7 +7800,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.15  nmos
+.model  nfet_03v3.15  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -7953,9 +7953,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -8031,13 +8031,13 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 .ends nplus_u_m1
 
 
-.endl nmos_3p3_f
+.endl nfet_03v3_f
 *
 *
-.lib nmos_3p3_s
+.lib nfet_03v3_s
 
 
-.subckt nmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt nfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.007148  
@@ -8058,11 +8058,11 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b nplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b nplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b nfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
-.model  nmos_3p3.0  nmos
+.model  nfet_03v3.0  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -8274,9 +8274,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -8306,7 +8306,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.1  nmos
+.model  nfet_03v3.1  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -8517,9 +8517,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -8549,7 +8549,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.2  nmos
+.model  nfet_03v3.2  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -8752,9 +8752,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -8784,7 +8784,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.3  nmos
+.model  nfet_03v3.3  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -8953,9 +8953,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -8985,7 +8985,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.4  nmos
+.model  nfet_03v3.4  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -9192,9 +9192,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -9224,7 +9224,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.5  nmos
+.model  nfet_03v3.5  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -9435,9 +9435,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -9467,7 +9467,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.6  nmos
+.model  nfet_03v3.6  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -9673,9 +9673,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -9705,7 +9705,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.7  nmos
+.model  nfet_03v3.7  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -9870,9 +9870,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -9902,7 +9902,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.8  nmos
+.model  nfet_03v3.8  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -10116,9 +10116,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -10148,7 +10148,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.9  nmos
+.model  nfet_03v3.9  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -10351,9 +10351,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -10383,7 +10383,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.10  nmos
+.model  nfet_03v3.10  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -10596,9 +10596,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -10628,7 +10628,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.11  nmos
+.model  nfet_03v3.11  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -10796,9 +10796,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -10828,7 +10828,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.12  nmos
+.model  nfet_03v3.12  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -11006,9 +11006,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -11038,7 +11038,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.13  nmos
+.model  nfet_03v3.13  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -11208,9 +11208,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -11240,7 +11240,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.14  nmos
+.model  nfet_03v3.14  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -11416,9 +11416,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -11448,7 +11448,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.15  nmos
+.model  nfet_03v3.15  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -11601,9 +11601,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -11679,14 +11679,14 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 *-------------------
 .ends nplus_u_m1
 
-.endl nmos_3p3_s
+.endl nfet_03v3_s
 *
 *
-.lib nmos_3p3_fs
+.lib nfet_03v3_fs
 
 
 
-.subckt nmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt nfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.007148  
@@ -11707,12 +11707,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b nplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b nplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b nfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  nmos_3p3.0  nmos
+.model  nfet_03v3.0  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -11924,9 +11924,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -11956,7 +11956,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.1  nmos
+.model  nfet_03v3.1  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -12167,9 +12167,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -12199,7 +12199,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.2  nmos
+.model  nfet_03v3.2  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -12402,9 +12402,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -12434,7 +12434,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.3  nmos
+.model  nfet_03v3.3  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -12603,9 +12603,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -12635,7 +12635,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.4  nmos
+.model  nfet_03v3.4  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -12842,9 +12842,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -12874,7 +12874,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.5  nmos
+.model  nfet_03v3.5  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -13085,9 +13085,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -13117,7 +13117,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.6  nmos
+.model  nfet_03v3.6  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -13323,9 +13323,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -13355,7 +13355,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.7  nmos
+.model  nfet_03v3.7  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -13520,9 +13520,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -13552,7 +13552,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.8  nmos
+.model  nfet_03v3.8  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -13766,9 +13766,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -13798,7 +13798,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.9  nmos
+.model  nfet_03v3.9  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -14001,9 +14001,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -14033,7 +14033,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.10  nmos
+.model  nfet_03v3.10  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -14246,9 +14246,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -14278,7 +14278,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.11  nmos
+.model  nfet_03v3.11  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -14446,9 +14446,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -14478,7 +14478,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.12  nmos
+.model  nfet_03v3.12  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -14656,9 +14656,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -14688,7 +14688,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.13  nmos
+.model  nfet_03v3.13  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -14858,9 +14858,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -14890,7 +14890,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.14  nmos
+.model  nfet_03v3.14  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -15066,9 +15066,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -15098,7 +15098,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.15  nmos
+.model  nfet_03v3.15  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -15251,9 +15251,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -15332,14 +15332,14 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 
 
-.endl nmos_3p3_fs
+.endl nfet_03v3_fs
 *
 *
-.lib nmos_3p3_sf
+.lib nfet_03v3_sf
 
 
 
-.subckt nmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt nfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.007148  
@@ -15360,12 +15360,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b nplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b nplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b nfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  nmos_3p3.0  nmos
+.model  nfet_03v3.0  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -15577,9 +15577,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -15609,7 +15609,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.1  nmos
+.model  nfet_03v3.1  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -15820,9 +15820,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -15852,7 +15852,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.2  nmos
+.model  nfet_03v3.2  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -16055,9 +16055,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -16087,7 +16087,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.3  nmos
+.model  nfet_03v3.3  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -16256,9 +16256,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -16288,7 +16288,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.4  nmos
+.model  nfet_03v3.4  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -16495,9 +16495,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -16527,7 +16527,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.5  nmos
+.model  nfet_03v3.5  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -16738,9 +16738,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -16770,7 +16770,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.6  nmos
+.model  nfet_03v3.6  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -16976,9 +16976,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -17008,7 +17008,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.7  nmos
+.model  nfet_03v3.7  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -17173,9 +17173,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -17205,7 +17205,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.8  nmos
+.model  nfet_03v3.8  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -17419,9 +17419,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -17451,7 +17451,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.9  nmos
+.model  nfet_03v3.9  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -17654,9 +17654,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -17686,7 +17686,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.10  nmos
+.model  nfet_03v3.10  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -17899,9 +17899,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -17931,7 +17931,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.11  nmos
+.model  nfet_03v3.11  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -18099,9 +18099,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -18131,7 +18131,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.12  nmos
+.model  nfet_03v3.12  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -18309,9 +18309,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -18341,7 +18341,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.13  nmos
+.model  nfet_03v3.13  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -18511,9 +18511,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -18543,7 +18543,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.14  nmos
+.model  nfet_03v3.14  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -18719,9 +18719,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -18751,7 +18751,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.15  nmos
+.model  nfet_03v3.15  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -18904,9 +18904,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -18983,16 +18983,16 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 .ends nplus_u_m1
 
 
-.endl nmos_3p3_sf
+.endl nfet_03v3_sf
 *
 ***************************************************************************************************
 * 3.3V PMOS Models
 ***************************************************************************************************
 *
-.lib pmos_3p3_t
+.lib pfet_03v3_t
 
 
-.subckt pmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.00666  
@@ -19013,12 +19013,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b pplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b pfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  pmos_3p3.0  pmos
+.model  pfet_03v3.0  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -19223,9 +19223,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -19264,7 +19264,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.1  pmos
+.model  pfet_03v3.1  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -19465,9 +19465,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -19506,7 +19506,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.2  pmos
+.model  pfet_03v3.2  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -19711,9 +19711,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -19752,7 +19752,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.3  pmos
+.model  pfet_03v3.3  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -19918,9 +19918,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -19959,7 +19959,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.4  pmos
+.model  pfet_03v3.4  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -20159,9 +20159,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -20200,7 +20200,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.5  pmos
+.model  pfet_03v3.5  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -20399,9 +20399,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -20440,7 +20440,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.6  pmos
+.model  pfet_03v3.6  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -20642,9 +20642,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -20683,7 +20683,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.7  pmos
+.model  pfet_03v3.7  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -20847,9 +20847,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -20888,7 +20888,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.8  pmos
+.model  pfet_03v3.8  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -21091,9 +21091,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -21132,7 +21132,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.9  pmos
+.model  pfet_03v3.9  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -21336,9 +21336,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -21377,7 +21377,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.10  pmos
+.model  pfet_03v3.10  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -21580,9 +21580,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -21621,7 +21621,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.11  pmos
+.model  pfet_03v3.11  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -21782,9 +21782,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -21823,7 +21823,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.12  pmos
+.model  pfet_03v3.12  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -21990,9 +21990,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -22031,7 +22031,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.13  pmos
+.model  pfet_03v3.13  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -22199,9 +22199,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -22240,7 +22240,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.14  pmos
+.model  pfet_03v3.14  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -22409,9 +22409,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -22450,7 +22450,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.15  pmos
+.model  pfet_03v3.15  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -22601,9 +22601,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -22687,13 +22687,13 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 
 
-.endl pmos_3p3_t
+.endl pfet_03v3_t
 *
 *
-.lib pmos_3p3_f
+.lib pfet_03v3_f
 
 
-.subckt pmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.00666  
@@ -22714,13 +22714,13 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b pplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b pfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
 
-.model  pmos_3p3.0  pmos
+.model  pfet_03v3.0  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -22925,9 +22925,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -22966,7 +22966,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.1  pmos
+.model  pfet_03v3.1  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -23167,9 +23167,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -23208,7 +23208,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.2  pmos
+.model  pfet_03v3.2  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -23413,9 +23413,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -23454,7 +23454,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.3  pmos
+.model  pfet_03v3.3  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -23620,9 +23620,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -23661,7 +23661,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.4  pmos
+.model  pfet_03v3.4  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -23861,9 +23861,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -23902,7 +23902,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.5  pmos
+.model  pfet_03v3.5  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -24101,9 +24101,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -24142,7 +24142,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.6  pmos
+.model  pfet_03v3.6  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -24344,9 +24344,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -24385,7 +24385,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.7  pmos
+.model  pfet_03v3.7  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -24549,9 +24549,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -24590,7 +24590,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.8  pmos
+.model  pfet_03v3.8  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -24793,9 +24793,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -24834,7 +24834,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.9  pmos
+.model  pfet_03v3.9  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -25038,9 +25038,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -25079,7 +25079,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.10  pmos
+.model  pfet_03v3.10  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -25282,9 +25282,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -25323,7 +25323,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.11  pmos
+.model  pfet_03v3.11  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -25484,9 +25484,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -25525,7 +25525,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.12  pmos
+.model  pfet_03v3.12  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -25692,9 +25692,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -25733,7 +25733,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.13  pmos
+.model  pfet_03v3.13  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -25901,9 +25901,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -25942,7 +25942,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.14  pmos
+.model  pfet_03v3.14  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -26111,9 +26111,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -26152,7 +26152,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.15  pmos
+.model  pfet_03v3.15  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -26303,9 +26303,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -26389,13 +26389,13 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 
 
-.endl pmos_3p3_f
+.endl pfet_03v3_f
 *
 *
-.lib pmos_3p3_s
+.lib pfet_03v3_s
 
 
-.subckt pmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.00666  
@@ -26416,12 +26416,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b pplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b pfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  pmos_3p3.0  pmos
+.model  pfet_03v3.0  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -26626,9 +26626,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -26667,7 +26667,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.1  pmos
+.model  pfet_03v3.1  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -26868,9 +26868,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -26909,7 +26909,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.2  pmos
+.model  pfet_03v3.2  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -27114,9 +27114,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -27155,7 +27155,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.3  pmos
+.model  pfet_03v3.3  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -27321,9 +27321,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -27362,7 +27362,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.4  pmos
+.model  pfet_03v3.4  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -27562,9 +27562,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -27603,7 +27603,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.5  pmos
+.model  pfet_03v3.5  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -27802,9 +27802,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -27843,7 +27843,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.6  pmos
+.model  pfet_03v3.6  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -28045,9 +28045,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -28086,7 +28086,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.7  pmos
+.model  pfet_03v3.7  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -28250,9 +28250,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -28291,7 +28291,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.8  pmos
+.model  pfet_03v3.8  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -28494,9 +28494,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -28535,7 +28535,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.9  pmos
+.model  pfet_03v3.9  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -28739,9 +28739,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -28780,7 +28780,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.10  pmos
+.model  pfet_03v3.10  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -28983,9 +28983,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -29024,7 +29024,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.11  pmos
+.model  pfet_03v3.11  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -29185,9 +29185,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -29226,7 +29226,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.12  pmos
+.model  pfet_03v3.12  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -29393,9 +29393,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -29434,7 +29434,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.13  pmos
+.model  pfet_03v3.13  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -29602,9 +29602,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -29643,7 +29643,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.14  pmos
+.model  pfet_03v3.14  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -29812,9 +29812,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -29853,7 +29853,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.15  pmos
+.model  pfet_03v3.15  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -30004,9 +30004,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -30089,13 +30089,13 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 
 
-.endl pmos_3p3_s
+.endl pfet_03v3_s
 *
 *
-.lib pmos_3p3_fs
+.lib pfet_03v3_fs
 
 
-.subckt pmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.00666  
@@ -30116,12 +30116,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b pplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b pfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  pmos_3p3.0  pmos
+.model  pfet_03v3.0  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -30326,9 +30326,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -30367,7 +30367,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.1  pmos
+.model  pfet_03v3.1  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -30568,9 +30568,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -30609,7 +30609,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.2  pmos
+.model  pfet_03v3.2  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -30814,9 +30814,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -30855,7 +30855,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.3  pmos
+.model  pfet_03v3.3  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -31021,9 +31021,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -31062,7 +31062,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.4  pmos
+.model  pfet_03v3.4  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -31262,9 +31262,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -31303,7 +31303,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.5  pmos
+.model  pfet_03v3.5  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -31502,9 +31502,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -31543,7 +31543,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.6  pmos
+.model  pfet_03v3.6  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -31745,9 +31745,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -31786,7 +31786,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.7  pmos
+.model  pfet_03v3.7  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -31950,9 +31950,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -31991,7 +31991,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.8  pmos
+.model  pfet_03v3.8  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -32194,9 +32194,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -32235,7 +32235,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.9  pmos
+.model  pfet_03v3.9  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -32439,9 +32439,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -32480,7 +32480,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.10  pmos
+.model  pfet_03v3.10  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -32683,9 +32683,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -32724,7 +32724,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.11  pmos
+.model  pfet_03v3.11  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -32885,9 +32885,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -32926,7 +32926,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.12  pmos
+.model  pfet_03v3.12  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -33093,9 +33093,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -33134,7 +33134,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.13  pmos
+.model  pfet_03v3.13  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -33302,9 +33302,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -33343,7 +33343,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.14  pmos
+.model  pfet_03v3.14  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -33512,9 +33512,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -33553,7 +33553,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.15  pmos
+.model  pfet_03v3.15  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -33704,9 +33704,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -33788,12 +33788,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 *-------------------
 .ends pplus_u_m1
 
-.endl pmos_3p3_fs
+.endl pfet_03v3_fs
 *
 *
-.lib pmos_3p3_sf
+.lib pfet_03v3_sf
 
-.subckt pmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.00666  
@@ -33814,12 +33814,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b pplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b pfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  pmos_3p3.0  pmos
+.model  pfet_03v3.0  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -34024,9 +34024,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -34065,7 +34065,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.1  pmos
+.model  pfet_03v3.1  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -34266,9 +34266,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -34307,7 +34307,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.2  pmos
+.model  pfet_03v3.2  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -34512,9 +34512,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -34553,7 +34553,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.3  pmos
+.model  pfet_03v3.3  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -34719,9 +34719,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -34760,7 +34760,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.4  pmos
+.model  pfet_03v3.4  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -34960,9 +34960,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -35001,7 +35001,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.5  pmos
+.model  pfet_03v3.5  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -35200,9 +35200,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -35241,7 +35241,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.6  pmos
+.model  pfet_03v3.6  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -35443,9 +35443,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -35484,7 +35484,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.7  pmos
+.model  pfet_03v3.7  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -35648,9 +35648,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -35689,7 +35689,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.8  pmos
+.model  pfet_03v3.8  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -35892,9 +35892,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -35933,7 +35933,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.9  pmos
+.model  pfet_03v3.9  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -36137,9 +36137,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -36178,7 +36178,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.10  pmos
+.model  pfet_03v3.10  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -36381,9 +36381,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -36422,7 +36422,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.11  pmos
+.model  pfet_03v3.11  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -36583,9 +36583,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -36624,7 +36624,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.12  pmos
+.model  pfet_03v3.12  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -36791,9 +36791,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -36832,7 +36832,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.13  pmos
+.model  pfet_03v3.13  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -37000,9 +37000,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -37041,7 +37041,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.14  pmos
+.model  pfet_03v3.14  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -37210,9 +37210,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -37251,7 +37251,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.15  pmos
+.model  pfet_03v3.15  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -37402,9 +37402,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -37488,17 +37488,17 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
  
 
-.endl pmos_3p3_sf
+.endl pfet_03v3_sf
 *
 *
 ***************************************************************************************************
 * 6V NMOS Models
 ***************************************************************************************************
 *
-.lib nmos_6p0_t
+.lib nfet_06v0_t
 
 
-.subckt nmos_6p0_sab d g s b w=10u l=0.6u par=1 s_sab=0.28u d_sab=3.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt nfet_06v0_dss d g s b w=10u l=0.6u par=1 s_sab=0.28u d_sab=3.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.01155  
@@ -37519,7 +37519,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b nplus_u_m2 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b nplus_u_m2 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=0 sb=0 sd=0
+m0 d1 g s1 b nfet_06v0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=0 sb=0 sd=0
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
@@ -37527,22 +37527,22 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 
 
 
-.model  nmos_6p0.0  nmos  level = 54
+.model  nfet_06v0.0  nmos  level = 54
 +lmin    = 7e-007          lmax    = 5.0001e-005     wmin    = 3e-007          wmax    = 0.000100001
 +version = 4.5             binunit = 1               paramchk= 1               mobmod  = 0
 +capmod  = 2               igcmod  = 0               igbmod  = 0               geomod  = 0
 +diomod  = 1               rdsmod  = 0               rbodymod= 0               rgeomod = 0
 +rgatemod= 0               permod  = 1               acnqsmod= 0               trnqsmod= 0
 +tempmod = 0               wpemod  = 0
-+tnom    = 25              toxe    = '1.52e-008+nmos_6p0_tox'       toxp    = '1.6e-008+nmos_6p0_tox'        toxm    = '1.52e-008+nmos_6p0_tox'
++tnom    = 25              toxe    = '1.52e-008+nfet_06v0_tox'       toxp    = '1.6e-008+nfet_06v0_tox'        toxm    = '1.52e-008+nfet_06v0_tox'
 +epsrox  = 3.9             toxref  = 1.52e-008       wint    = 1.55e-008       lint    = -3e-008
 +ll      = 1.93e-014       wl      = 0               lln     = 1               wln     = 1
 +lw      = 0               ww      = -2.7e-015       lwn     = 1               wwn     = 1
 +lwl     = 0               wwl     = 0               llc     = 0               wlc     = 0
 +lwc     = 0               wwc     = 0               lwlc    = 0               wwlc    = 0
-+xl      = '0+nmos_6p0_xl'               xw      = '0+nmos_6p0_xw'               dlc     = 5.4E-8               dwc     = 0
++xl      = '0+nfet_06v0_xl'               xw      = '0+nfet_06v0_xw'               dlc     = 5.4E-8               dwc     = 0
 +dlcig   = 0               xpart   = 0
-+vth0    = '0.67314+nmos_6p0_vth0'         k1      = 0.9             k2      = -0.001          k3      = -1.1369995
++vth0    = '0.67314+nfet_06v0_vth0'         k1      = 0.9             k2      = -0.001          k3      = -1.1369995
 +wk3     = -0.047531062    k3b     = 0.86            w0      = 1e-009          dvt0    = 5.72
 +dvt1    = 0.299           dvt2    = -0.0793         dvt0w   = 10              dvt1w   = 976700
 +dvt2w   = 0.15            dsub    = 0.4             minv    = 0               voffl   = 0
@@ -37556,8 +37556,8 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +ua      = 6.8000001e-012  lua     = -3.3696895e-019  wua     = -8.4912706e-019  pua     = 1.4622721e-010
 +ub      = 2.8799997e-018  lub     = 1.7400001e-018  wub     = -1.1655759e-026  pub     = -2.3803999e-019
 +uc      = 7.9399996e-011  luc     = 9.8000018e-011  wuc     = 8.0000028e-012  puc     = -5.6168065e-012
-+eu      = 1.67            vsat    = '103999.98*nmos_6p0_vsat'       lvsat   = '-2649.9871*nmos_6p0_vsat'      wvsat   = '0.012447116*nmos_6p0_vsat'
-+pvsat   = '6308.7992*nmos_6p0_vsat'       a0      = 0.72499969      la0     = 0.40144032      ags     = 0.13699995
++eu      = 1.67            vsat    = '103999.98*nfet_06v0_vsat'       lvsat   = '-2649.9871*nfet_06v0_vsat'      wvsat   = '0.012447116*nfet_06v0_vsat'
++pvsat   = '6308.7992*nfet_06v0_vsat'       a0      = 0.72499969      la0     = 0.40144032      ags     = 0.13699995
 +lags    = -0.068999933    wags    = -4.2211594e-008  pags    = 0.0070910278    a1      = 0
 +a2      = 0.96            b0      = 0               b1      = 0               keta    = -0.021200021
 +lketa   = 0.04140001      dwg     = -6e-010         dwb     = 6e-009          pclm    = 0.0099999763
@@ -37574,8 +37574,8 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +bigc    = 0.054           cigc    = 0.075           aigsd   = 0.43            bigsd   = 0.054
 +cigsd   = 0.075           nigc    = 1               poxedge = 1               pigcd   = 1
 +ntox    = 1               vfbsdoff= 0
-+cgso    = '1e-010*nmos_6p0_cgso'          cgdo    = '1e-010*nmos_6p0_cgdo'          cgbo    = 1e-013          cgdl    = '1.5e-010*nmos_6p0_cgdo'
-+cgsl    = '1.5e-010*nmos_6p0_cgso'        clc     = 1e-010          cle     = 0.6             ckappas = 0.6
++cgso    = '1e-010*nfet_06v0_cgso'          cgdo    = '1e-010*nfet_06v0_cgdo'          cgbo    = 1e-013          cgdl    = '1.5e-010*nfet_06v0_cgdo'
++cgsl    = '1.5e-010*nfet_06v0_cgso'        clc     = 1e-010          cle     = 0.6             ckappas = 0.6
 +ckappad = 0.6             vfbcv   = -1              acde    = 0.3             moin    = 15
 +noff    = 1.5             voffcv  = 0
 +tvoff   = 0               tvfbsdoff= 0               kt1     = -0.412          kt1l    = 3.5e-008
@@ -37584,7 +37584,7 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +luc1    = -1.8816003e-011  prt     = 0               at      = 109000.03       lat     = -75600.021
 +wat     = 6479.9797       pat     = -6699.9857
 +fnoimod = 1               tnoimod = 0               em      = 4.1e+007        ef      = 1
-+noia    = 'nmos_6p0_noia'       noib    = 'nmos_6p0_noib'      noic    = 'nmos_6p0_noic'       ntnoi   = 1
++noia    = 'nfet_06v0_noia'       noib    = 'nfet_06v0_noib'      noic    = 'nfet_06v0_noic'       ntnoi   = 1
 +lintnoi = 0
 +jss     = 6.88e-007       jsws    = 4.88e-013       jswgs   = 0               njs     = 1.0541
 +ijthsfwd= 0.1             ijthsrev= 0.1             bvs     = 11              xjbvs   = 1
@@ -37618,22 +37618,22 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wku0    = 0               pku0    = 0               llodku0 = 0               wlodku0 = 0
 +kvsat   = 0               steta0  = 0               tku0    = 0
 
-.model  nmos_6p0.1  nmos  level = 54
+.model  nfet_06v0.1  nmos  level = 54
 +lmin    = 6e-007          lmax    = 7e-007          wmin    = 3e-007          wmax    = 0.000100001
 +version = 4.5             binunit = 1               paramchk= 1               mobmod  = 0
 +capmod  = 2               igcmod  = 0               igbmod  = 0               geomod  = 0
 +diomod  = 1               rdsmod  = 0               rbodymod= 0               rgeomod = 0
 +rgatemod= 0               permod  = 1               acnqsmod= 0               trnqsmod= 0
 +tempmod = 0               wpemod  = 0
-+tnom    = 25              toxe    = '1.52e-008+nmos_6p0_tox'       toxp    = '1.6e-008+nmos_6p0_tox'        toxm    = '1.52e-008+nmos_6p0_tox'
++tnom    = 25              toxe    = '1.52e-008+nfet_06v0_tox'       toxp    = '1.6e-008+nfet_06v0_tox'        toxm    = '1.52e-008+nfet_06v0_tox'
 +epsrox  = 3.9             toxref  = 1.52e-008       wint    = 1.55e-008       lint    = -3e-008
 +ll      = 1.93e-014       wl      = 0               lln     = 1               wln     = 1
 +lw      = 0               ww      = -2.7e-015       lwn     = 1               wwn     = 1
 +lwl     = 0               wwl     = 0               llc     = 0               wlc     = 0
 +lwc     = 0               wwc     = 0               lwlc    = 0               wwlc    = 0
-+xl      = '0+nmos_6p0_xl'               xw      = '0+nmos_6p0_xw'               dlc     = 5.4E-8               dwc     = 0
++xl      = '0+nfet_06v0_xl'               xw      = '0+nfet_06v0_xw'               dlc     = 5.4E-8               dwc     = 0
 +dlcig   = 0               xpart   = 0
-+vth0    = '0.67314+nmos_6p0_vth0'         k1      = 0.9             k2      = -0.001          k3      = -1.1369995
++vth0    = '0.67314+nfet_06v0_vth0'         k1      = 0.9             k2      = -0.001          k3      = -1.1369995
 +wk3     = -0.047531062    k3b     = 0.86            w0      = 1e-009          dvt0    = 5.72
 +dvt1    = 0.299           dvt2    = -0.0793         dvt0w   = 10              dvt1w   = 976700
 +dvt2w   = 0.15            dsub    = 0.4             minv    = 0               voffl   = 0
@@ -37647,8 +37647,8 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +ua      = 6.7999991e-012  lua     = 3.7339196e-019  wua     = 1.3244868e-016  pua     = 1.4622711e-010
 +ub      = 2.8800011e-018  lub     = 1.7399991e-018  wub     = 1.8765824e-025  pub     = -2.3804013e-019
 +uc      = 7.9400388e-011  luc     = 9.7999741e-011  wuc     = 7.9999428e-012  puc     = -5.6167642e-012
-+eu      = 1.67            vsat    = '64848.09*nmos_6p0_vsat'        lvsat   = '24946.5*nmos_6p0_vsat'         wvsat   = '0.14568305*nmos_6p0_vsat'
-+pvsat   = '6308.7053*nmos_6p0_vsat'       a0      = 0.72500081      la0     = 0.40143954      ags     = 0.13700019
++eu      = 1.67            vsat    = '64848.09*nfet_06v0_vsat'        lvsat   = '24946.5*nfet_06v0_vsat'         wvsat   = '0.14568305*nfet_06v0_vsat'
++pvsat   = '6308.7053*nfet_06v0_vsat'       a0      = 0.72500081      la0     = 0.40143954      ags     = 0.13700019
 +lags    = -0.069000099    wags    = 5.7853969e-008  pags    = 0.0070909573    a1      = 0
 +a2      = 0.96            b0      = 0               b1      = 0               keta    = -0.021200265
 +lketa   = 0.041400183     dwg     = -6e-010         dwb     = 6e-009          pclm    = 0.0099996572
@@ -37665,8 +37665,8 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +bigc    = 0.054           cigc    = 0.075           aigsd   = 0.43            bigsd   = 0.054
 +cigsd   = 0.075           nigc    = 1               poxedge = 1               pigcd   = 1
 +ntox    = 1               vfbsdoff= 0
-+cgso    = '1e-010*nmos_6p0_cgso'          cgdo    = '1e-010*nmos_6p0_cgdo'          cgbo    = 1e-013          cgdl    = '1.5e-010*nmos_6p0_cgdo'
-+cgsl    = '1.5e-010*nmos_6p0_cgso'        clc     = 1e-010          cle     = 0.6             ckappas = 0.6
++cgso    = '1e-010*nfet_06v0_cgso'          cgdo    = '1e-010*nfet_06v0_cgdo'          cgbo    = 1e-013          cgdl    = '1.5e-010*nfet_06v0_cgdo'
++cgsl    = '1.5e-010*nfet_06v0_cgso'        clc     = 1e-010          cle     = 0.6             ckappas = 0.6
 +ckappad = 0.6             vfbcv   = -1              acde    = 0.3             moin    = 15
 +noff    = 1.5             voffcv  = 0
 +tvoff   = 0               tvfbsdoff= 0               kt1     = -0.412          kt1l    = 3.5e-008
@@ -37675,7 +37675,7 @@ m0 d1 g s1 b nmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +luc1    = -1.8816017e-011  prt     = 0               at      = -119957.68      lat     = 85782.454
 +wat     = -33999.727      pat     = 21832.424
 +fnoimod = 1               tnoimod = 0               em      = 4.1e+007        ef      = 1
-+noia    = 'nmos_6p0_noia'   noib    = 'nmos_6p0_noib'      noic    = 'nmos_6p0_noic'       ntnoi   = 1
++noia    = 'nfet_06v0_noia'   noib    = 'nfet_06v0_noib'      noic    = 'nfet_06v0_noic'       ntnoi   = 1
 +lintnoi = 0
 +jss     = 6.88e-007       jsws    = 4.88e-013       jswgs   = 0               njs     = 1.0541
 +ijthsfwd= 0.1             ijthsrev= 0.1             bvs     = 11              xjbvs   = 1
@@ -37753,20 +37753,20 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 *-------------------
 .ends nplus_u_m2
 
-.endl nmos_6p0_t
+.endl nfet_06v0_t
 *
 ***************************************************************************************************
 * 6V native NMOS Models
 ***************************************************************************************************
 *
-.lib nmos_6p0_nat_t
-.subckt nmos_6p0_nat d g s b w=1e-5 l=1.8e-6 as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0 sa=0 sb=0 nf=1 sd=0 m=1
+.lib nfet_06v0_nvt_t
+.subckt nfet_06v0_nvt d g s b w=1e-5 l=1.8e-6 as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0 sa=0 sb=0 nf=1 sd=0 m=1
 
-m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb=sb nf=nf sd=sd
+m0 d g s b nfet_06v0_nvt w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb=sb nf=nf sd=sd
 
-.ends nmos_6p0_nat
+.ends nfet_06v0_nvt
 
-.model  nmos_6p0_nat.0  nmos
+.model  nfet_06v0_nvt.0  nmos
 +level = 54
 **************************************************************
 *               MODEL FLAG PARAMETERS 
@@ -37782,7 +37782,7 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 **************************************************************
 *               GENERAL MODEL PARAMETERS 
 **************************************************************
-+tnom    = 25              toxe    = nmos_6p0_nat_tox   toxp    = 1.6e-008      
++tnom    = 25              toxe    = nfet_06v0_nvt_tox   toxp    = 1.6e-008      
 +toxm    = 1.52e-008       epsrox  = 3.9             toxref  = 1.52e-008     
 +wint    = 1e-009          lint    = 1e-007          ll      = 0             
 +wl      = 0               lln     = 1               wln     = 1             
@@ -37790,12 +37790,12 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 +wwn     = 1               lwl     = 0               wwl     = 0             
 +llc     = 0               wlc     = 0               lwc     = 0             
 +wwc     = 0               lwlc    = 0               wwlc    = 0             
-+xl      = nmos_6p0_nat_xl    xw      = nmos_6p0_nat_xw     dlc     = 0             
++xl      = nfet_06v0_nvt_xl    xw      = nfet_06v0_nvt_xw     dlc     = 0             
 +dwc     = 0               dlcig   = 0               xpart   = 0             
 **************************************************************
 *               DC PARAMETERS 
 **************************************************************
-+vth0    = nmos_6p0_nat_vth0   lvth0   = -0.088           k1      = 0.165         
++vth0    = nfet_06v0_nvt_vth0   lvth0   = -0.088           k1      = 0.165         
 +k2      = -0.001          k3      = -0.6            k3b     = -0.6          
 +w0      = 1e-010          dvt0    = 2.2             dvt1    = 0.53          
 +dvt2    = -0.032          dvt0w   = 0               dvt1w   = 5300000       
@@ -37808,7 +37808,7 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 +cdscb   = 0               cdscd   = 0               cit     = 0             
 +voff    = -0.06           ud1     = 0               up      = 0             
 +lp      = 1e-008          nfactor = 0.40241         lnfactor= 0.45          
-+eta0    = 0.06            etab    = -0.43           u0      = nmos_6p0_nat_u0     
++eta0    = 0.06            etab    = -0.43           u0      = nfet_06v0_nvt_u0     
 +lu0     = 0.042           ua      = 2.278e-009      ub      = 3.97e-019     
 +lub     = 3.65e-018       uc      = 2.625e-012      eu      = 1.67          
 +vsat    = 106700          pvsat   = 23500           a0      = 0.88          
@@ -37835,7 +37835,7 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 **************************************************************
 *               CAPACITANCE PARAMETERS 
 **************************************************************
-+cgso    = nmos_6p0_nat_cgso   cgdo    = nmos_6p0_nat_cgdo   cgbo    = 1e-013        
++cgso    = nfet_06v0_nvt_cgso   cgdo    = nfet_06v0_nvt_cgdo   cgbo    = 1e-013        
 +cgdl    = 1.5e-010        cgsl    = 1.5e-010        clc     = 1e-010        
 +cle     = 0.6             ckappas = 0.6             ckappad = 0.6           
 +vfbcv   = -1              acde    = 0.3             moin    = 15            
@@ -37852,8 +37852,8 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 *               NOISE PARAMETERS 
 **************************************************************
 +fnoimod = 1               tnoimod = 0               em      = 4.1e+007      
-+ef      = 1               noia    = 'nmos_6p0_nat_noia'        noib    = 'nmos_6p0_nat_noib'      
-+noic    = 'nmos_6p0_nat_noic'          ntnoi   = 1               lintnoi = 0             
++ef      = 1               noia    = 'nfet_06v0_nvt_noia'        noib    = 'nfet_06v0_nvt_noib'      
++noic    = 'nfet_06v0_nvt_noic'          ntnoi   = 1               lintnoi = 0             
 **************************************************************
 *               DIODE PARAMETERS 
 **************************************************************
@@ -37907,16 +37907,16 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 +pku0    = 0               llodku0 = 0               wlodku0 = 0             
 +kvsat   = 0               steta0  = 0               tku0    = 0             
 
-.endl nmos_6p0_nat_t
+.endl nfet_06v0_nvt_t
 *
 ***************************************************************************************************
 * 6V PMOS Models
 ***************************************************************************************************
 *
-.lib pmos_6p0_t
+.lib pfet_06v0_t
 
 
-.subckt pmos_6p0_sab d g s b w=10u l=0.5u par=1 s_sab=0.28u d_sab=2.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_06v0_dss d g s b w=10u l=0.5u par=1 s_sab=0.28u d_sab=2.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.01051 
@@ -37937,12 +37937,12 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 
 xr1 d d1 b pplus_u_m2 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m2 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=0 sb=0 sd=0
+m0 d1 g s1 b pfet_06v0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=0 sb=0 sd=0
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model pmos_6p0.0 pmos
+.model pfet_06v0.0 pmos
 ***** Flag Parameter ***
 +level = 54                    version = 4.6                 binunit = 1                   
 +paramchk = 1                  mobmod = 0                    capmod = 2                    
@@ -37954,7 +37954,7 @@ m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lmin = 0.5e-6                lmax = 50.01e-6               wmin = 0.3e-6                      
 +wmax = 100.01e-6                      
 ***** Process Parameter ***
-+epsrox = 3.9                  toxe = '1.56E-8+pmos_6p0_dtox' xj = 1.5E-7                   
++epsrox = 3.9                  toxe = '1.56E-8+pfet_06v0_dtox' xj = 1.5E-7                   
 +ndep = 1.7E17                 ngate = 3.6E19                nsd = 6E16                    
 +rsh = 7                       rshg = 0.1                    phin = 0                      
 +lphin = 0.1408                
@@ -37963,10 +37963,10 @@ m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +ww = -1.37E-14                wwn = 1                       wwl = 3.04E-22                
 +lint = 6.7E-8                 ll = -5.4E-15                 lln = 1                       
 +lw = 0                        lwn = 1                       lwl = -4.76E-21               
-+dwg = -6.6E-9                 dwb = -3E-9                   xl = '0+pmos_6p0_dxl'         
-+xw = '0+pmos_6p0_dxw'         
++dwg = -6.6E-9                 dwb = -3E-9                   xl = '0+pfet_06v0_dxl'         
++xw = '0+pfet_06v0_dxw'         
 ***** Vth Related  Parameter ***
-+vth0 = '-0.8978+pmos_6p0_dvth0' pvth0 = '7.6E-3+8.47e-3*pmos_6p0_dvth0' 
++vth0 = '-0.8978+pfet_06v0_dvth0' pvth0 = '7.6E-3+8.47e-3*pfet_06v0_dvth0' 
 +k1 = 0.9588                   k2 = 8.936E-3                 vfb = -1
 +k3 = -0.75                    k3b = 1.2104                  w0 = 3.1E-7                   
 +lpe0 = -4.4E-8                lpeb = -5.96E-8               dvtp0 = 0                     
@@ -38000,14 +38000,14 @@ m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +agidl = 1.1E-15               pagidl = 6.27545E-16          bgidl = 1.578E5               
 +egidl = 1.19653E-2  
 ***** Noise Parameters ***
-+ef      = 1.1                 noia    = 'pmos_6p0_noia'        
-+noib    = 'pmos_6p0_noib'     noic    = 'pmos_6p0_noic'                  
++ef      = 1.1                 noia    = 'pfet_06v0_noia'        
++noib    = 'pfet_06v0_noib'     noic    = 'pfet_06v0_noic'                  
 ***** Capacitance Parameter ***
-+xpart = 1                     cgso = '7.71E-11*pmos_6p0_dcgso' cgdo = '7.71E-11*pmos_6p0_dcgdo'               
++xpart = 1                     cgso = '7.71E-11*pfet_06v0_dcgso' cgdo = '7.71E-11*pfet_06v0_dcgdo'               
 +cgbo = 1E-13                  ckappas = 0.6                 ckappad = 0.6                 
 +dlc = 7.4E-9                  noff = 1                      voffcv = 0                    
-+acde = 0.7                    moin = 15                     cgsl = '5.25E-11*pmos_6p0_dcgso'               
-+cgdl = '5.25E-11*pmos_6p0_dcgdo'               
++acde = 0.7                    moin = 15                     cgsl = '5.25E-11*pfet_06v0_dcgso'               
++cgdl = '5.25E-11*pfet_06v0_dcgdo'               
 ***** Souce/Drain Junction Diode Model Parameter ***
 +ijthsrev = 0.1                ijthdrev = 0.1                ijthsfwd = 0.1                
 +ijthdfwd = 0.1                xjbvs = 1                     xjbvd = 1                     
@@ -38074,13 +38074,13 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 *-------------------
 .ends pplus_u_m2
 
-.endl pmos_6p0_t
+.endl pfet_06v0_t
 *
 *
 *
 .LIB dio
 
-.model  np_3p3  d  level = 3  
+.model  diode_nd2ps_03v3  d  level = 3  
 +tref    = 25            
 +is      = '2.2959e-007 * jsa'   
 +jsw     = '2.1207e-013 * jsa'  
@@ -38109,7 +38109,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 +tpb     = 0.0018129     
 +tphp    = 5e-005     
 *
-.model  pn_3p3  d  level = 3    
+.model  diode_pd2nw_03v3  d  level = 3    
 +tref    = 25            
 +is      = '1.653e-007 * jsa'   
 +jsw     = '2.1207e-013 * jsa'  
@@ -38138,7 +38138,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 +tpb     = 0.0016906     
 +tphp    = 0.0052   
 *
-.model  np_6p0  d  level = 3
+.model  diode_nd2ps_06v0  d  level = 3
 +tref    = 25            
 +is      = '6.88e-007 * jsa'      jsw     = '4.88e-013 * jsa'      ik      = 229000        
 +bv      = 11              ibv     = 0.001           ikr     = 1e-030        
@@ -38149,7 +38149,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 +xti     = 5               cta     = 0.000825        ctp     = 0.0018        
 +tpb     = 0.00146         tphp    = 0.00313          eg      = 1.11          
 
-.model  pn_6p0  d  level = 3
+.model  diode_pd2nw_06v0  d  level = 3
 +tref    = 25           
 +is      = '2.0867e-007 * jsa'  jsw     = '1.6088e-013 * jsa'  ik      = 253800                   
 +ikr     = 0               n       = 1.0058          rs      = '2.0e-010 * rsa'    
@@ -38159,7 +38159,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 +cta     = 0.001           ctp     = 0.00071888      tpb     = 0.0019314       tphp    = 0.0017642     
 +eg      = 1.17            bv=10.5
 *
-.model  nwp_3p3  d  level = 3
+.model  diode_nw2ps_03v3  d  level = 3
 +area    = 1.6e-009      
 +pj      = 0.00016       
 +tref    = 25            
@@ -38190,7 +38190,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 +tpb     = 0.0027641     
 +tphp    = 0.0019629     
 *
-.model  nwp_6p0  d  level = 3
+.model  diode_nw2ps_06v0  d  level = 3
 +tref    = 25            
 +is      = '1.6119e-006 * jsa' jsw   = '2e-012 * jsa'         ik      = 100000        
 +ikr     = 0               n       = 1              rs      = '2e-010 * rsa'          
@@ -38200,7 +38200,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 +cta     = 0.0028626       ctp     = 0.00091707     tpb     = 0.0024779       tphp    = 0.00125       
 +eg      = 1.1763          bv=14
 *
-.model  dnwpw  d  level = 3
+.model  diode_pw2dw  d  level = 3
 +tref    = 25            
 +is      = '5.2139e-007* jsa'     jsw     = '0* jsa'               ik      = 711930          vb      = 14.732        
 +ibv     = 0.001           ikr     = 0               n       = 0.98            rs      = '2e-010* rsa'   
@@ -38210,7 +38210,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 +cta     = 0.0012922       ctp     = 0.0010772       tpb     = 0.0019819       tphp    = 0.0016567     
 +eg      = 1.17
 *
-.model  dnwps  d  level = 3
+.model  diode_dw2ps  d  level = 3
 +tref    = 25            
 +is      = '2e-006* jsa'     jsw     = '1e-12* jsa'               ik      = 229050          vb      = 30.48         
 +ibv     = 0.001           ikr     = 0               n       = 0.99335         rs      = '2e-010* rsa'   
@@ -38312,7 +38312,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 + tc2=1.75E-6
 + tnom=25
 * model for substrate capacitor
-.model np_3p3 d
+.model diode_nd2ps_03v3 d
 + Level=3
 + Cj=0.00096797    
 + Mj=0.32071       
@@ -38329,12 +38329,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 *-------------------
 * terminal 1
 rt1 1 11 nplus_u_t   l='s*1u' w=r_w dtemp=dtemp
-d1  3 1  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d1  3 1  diode_nd2ps_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 * body
 rb  11 21 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)*(1+mis_r*sw_stat_mismatch)'
 * terminal 2
 rt2 21 2 nplus_u_t   l='s*1u' w=r_w dtemp=dtemp
-d2  3 2  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d2  3 2  diode_nd2ps_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 *-------------------
 .ends nplus_u
 *******************************************************************************************************
@@ -38369,7 +38369,7 @@ d2  3 2  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 + tc2=0.7E-6
 + tnom=25
 * model for substrate capacitor
-.model pn_3p3 d
+.model diode_pd2nw_03v3 d
 + Level=3
 + Cj=0.00094344    
 + Mj=0.32084       
@@ -38386,12 +38386,12 @@ d2  3 2  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 *-------------------
 * terminal 1
 rt1 1 11 pplus_u_t   l='s*1u' w=r_w dtemp=dtemp
-d1  1 3  pn_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d1  1 3  diode_pd2nw_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 * body
 rb  11 21 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)*(1+mis_r*sw_stat_mismatch)'
 * terminal 2
 rt2 21 2 pplus_u_t   l='s*1u' w=r_w dtemp=dtemp
-d2  2 3  pn_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d2  2 3  diode_pd2nw_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 *-------------------
 .ends pplus_u
 *******************************************************************************************************
@@ -38418,7 +38418,7 @@ d2  2 3  pn_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 + tc2=-0.27E-6
 + tnom=25
 * model for substrate capacitor
-.model np_3p3 d
+.model diode_nd2ps_03v3 d
 + Level=3
 + Cj=0.00096797    
 + Mj=0.32071       
@@ -38435,12 +38435,12 @@ d2  2 3  pn_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 *-------------------
 * terminal 1
 rt1 1 11 nplus_s_t   l='s*1u' w=r_w dtemp=dtemp
-d1  3 1  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d1  3 1  diode_nd2ps_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 * body
 rb  11 21 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)'
 * terminal 2
 rt2 21 2 nplus_s_t   l='s*1u' w=r_w dtemp=dtemp
-d2  3 2  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d2  3 2  diode_nd2ps_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 *-------------------
 .ends nplus_s
 *******************************************************************************************************
@@ -38467,7 +38467,7 @@ d2  3 2  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 + tc2=-0.028E-6
 + tnom=25
 * model for substrate capacitor
-.model pn_3p3 d
+.model diode_pd2nw_03v3 d
 + Level=3
 + Cj=0.00094344    
 + Mj=0.32084       
@@ -38484,12 +38484,12 @@ d2  3 2  np_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 *-------------------
 * terminal 1
 rt1 1 11 pplus_s_t   l='s*1u' w=r_w dtemp=dtemp
-d1  1 3  pn_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d1  1 3  diode_pd2nw_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 * body
 rb  11 21 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)'
 * terminal 2
 rt2 21 2 pplus_s_t   l='s*1u' w=r_w dtemp=dtemp
-d2  2 3  pn_3p3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
+d2  2 3  diode_pd2nw_03v3  area='r_w*r_l/2' pj='r_w+2*r_l/2' dtemp=dtemp
 *-------------------
 .ends pplus_s
 *******************************************************************************************************
@@ -39134,11 +39134,11 @@ rb 1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))
 *The models are obtained from YI-141-SM003 Rev. 1E.
 *
 * ----------------------------------------------------------------------------------------------------
-.LIB mim_cap
+.LIB cap_mim
 */ -------------------------------------------------------------------------------------
 */ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
 */--------------------------------------------------------------------------------------
-.subckt mim_1p5fF 1 2  c_length=l c_width=w dtemp=0 par=1
+.subckt cap_mim_1f5fF 1 2  c_length=l c_width=w dtemp=0 par=1
 .param
 + c_cox='1.47e-3*mim_corner_1p5fF'
 + c_capsw='3.79e-10*mim_corner_1p5fF'
@@ -39154,11 +39154,11 @@ rb 1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))
 */ model for capacitance
 c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
 **
-.ends mim_1p5fF
+.ends cap_mim_1f5
 */ -------------------------------------------------------------------------------------
 */ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
 */--------------------------------------------------------------------------------------
-.subckt mim_1p0fF 1 2  c_length=l c_width=w dtemp=0 par=1
+.subckt cap_mim_1f0fF 1 2  c_length=l c_width=w dtemp=0 par=1
 .param
 + c_cox='0.987e-3*mim_corner_1p0fF'
 + c_capsw='3.3e-10*mim_corner_1p0fF'
@@ -39174,11 +39174,11 @@ c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
 */ model for capacitance
 c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
 **
-.ends mim_1p0fF
+.ends cap_mim_1f0
 */ -------------------------------------------------------------------------------------
 */ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
 */--------------------------------------------------------------------------------------
-.subckt mim_2p0fF  1 2  c_length=l  c_width=w dtemp=0 par=1
+.subckt cap_mim_2f0fF  1 2  c_length=l  c_width=w dtemp=0 par=1
 .param gleak='9.51e-10/5*10000'
 .param c_cox='1.99e-3*mim_corner_2p0fF'
 .param c_capsw='2.383e-10*mim_corner_2p0fF'
@@ -39195,76 +39195,76 @@ c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
 *
 c_cap 1 2 c='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
 r_leak 1 2 r='1/(gleak*c_AREA)' tc1=c_tc1 tc2=c_tc2 dtemp=dtemp
-.ends mim_2p0fF
-.ENDL mim_cap
+.ends cap_mim_2f0
+.ENDL cap_mim
 * ----------------------------------------------------------------------------------------------------
 *
 *
 .LIB moscap
 
-.subckt nmoscap_3p3 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_nmos_03v3 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.002003
 .param cvar2=0.00198
 .param cvar3=6.25
 .param cvar4=-3.9375
-c_moscap 1 2 c='nmoscap_3p3_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends nmoscap_3p3
+c_moscap 1 2 c='cap_nmos_03v3_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_nmos_03v3
 *
-.subckt pmoscap_3p3 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_pmos_03v3 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.001998
 .param cvar2=0.00196
 .param cvar3=-6.25
 .param cvar4=-4.9375
-c_moscap 1 2 c='pmoscap_3p3_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends pmoscap_3p3
+c_moscap 1 2 c='cap_pmos_03v3_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_pmos_03v3
 *
-.subckt nmoscap_6p0 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_nmos_06v0 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.001107
 .param cvar2=0.00107
 .param cvar3=6.25
 .param cvar4=-4.1875
-c_moscap 1 2 c='nmoscap_6p0_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends nmoscap_6p0
+c_moscap 1 2 c='cap_nmos_06v0_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_nmos_06v0
 *
-.subckt pmoscap_6p0 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_pmos_06v0 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.001107
 .param cvar2=0.00107
 .param cvar3=-6.25
 .param cvar4=-5.75
-c_moscap 1 2 c='pmoscap_6p0_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends pmoscap_6p0
+c_moscap 1 2 c='cap_pmos_06v0_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_pmos_06v0
 *
-.subckt nmoscap_3p3_b 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_nmos_03v3_b 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.002458
 .param cvar2=0.001533
 .param cvar3=1.515152
 .param cvar4=0.560606
-c_moscap 1 2 c='nmoscap_3p3_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends nmoscap_3p3_b
+c_moscap 1 2 c='cap_nmos_03v3_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_nmos_03v3_b
 *
-.subckt pmoscap_3p3_b 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_pmos_03v3_b 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.002435
 .param cvar2=0.00154
 .param cvar3=-1.66667
 .param cvar4=0.65
-c_moscap 1 2 c='pmoscap_3p3_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends pmoscap_3p3_b
+c_moscap 1 2 c='cap_pmos_03v3_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_pmos_03v3_b
 *
-.subckt nmoscap_6p0_b 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_nmos_06v0_b 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.001293
 .param cvar2=0.000863
 .param cvar3=1.052632
 .param cvar4=0.736842
-c_moscap 1 2 c='nmoscap_6p0_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends nmoscap_6p0_b
+c_moscap 1 2 c='cap_nmos_06v0_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_nmos_06v0_b
 *
-.subckt pmoscap_6p0_b 1 2 c_length=l c_width=w dtemp=0
+.subckt cap_pmos_06v0_b 1 2 c_length=l c_width=w dtemp=0
 .param cvar1=0.001325
 .param cvar2=0.000865
 .param cvar3=-1.42857
 .param cvar4=0.642857
-c_moscap 1 2 c='pmoscap_6p0_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
-.ends pmoscap_6p0_b
+c_moscap 1 2 c='cap_pmos_06v0_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))' dtemp=dtemp
+.ends cap_pmos_06v0_b
 *
 .ENDL moscap
 *
@@ -39272,10 +39272,10 @@ c_moscap 1 2 c='pmoscap_6p0_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(
 * 3.3V NMOS statistical Models
 ***************************************************************************************************
 *
-.lib nmos_3p3_stat
+.lib nfet_03v3_stat
 
 
-.subckt nmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt nfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.007148  
@@ -39295,12 +39295,12 @@ c_moscap 1 2 c='pmoscap_6p0_b_corner*c_length*c_width*(cvar1+cvar2*tanh(cvar3*v(
 + mis_vth=agauss(0,var_vth,1)
 xr1 d d1 b nplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b nplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b nfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  nmos_3p3.0  nmos
+.model  nfet_03v3.0  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -39322,8 +39322,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -39338,14 +39338,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_0   
++vth0    = nfet_03v3_vth0_0   
 +lvth0   = -3.8715455e-008
 +wvth0   = -1.430587e-008
 +pvth0   = 4.3636364e-016
@@ -39372,7 +39372,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -39445,7 +39445,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -39512,9 +39512,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -39544,7 +39544,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.1  nmos
+.model  nfet_03v3.1  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -39566,8 +39566,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -39582,14 +39582,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_1    
++vth0    = nfet_03v3_vth0_1    
 +lvth0   = -2.3433061e-008
 +wvth0   = -1.2304653e-008
 +pvth0   = -5.642449e-016
@@ -39616,7 +39616,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -39690,7 +39690,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -39755,9 +39755,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -39787,7 +39787,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.2  nmos
+.model  nfet_03v3.2  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -39809,8 +39809,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -39825,14 +39825,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_2    
++vth0    = nfet_03v3_vth0_2    
 +lvth0   = -3.224026e-009
 +wvth0   = -9.7008312e-009
 +pvth0   = -3.6888312e-015
@@ -39859,7 +39859,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -39930,7 +39930,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -39990,9 +39990,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -40022,7 +40022,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.3  nmos
+.model  nfet_03v3.3  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -40044,8 +40044,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -40060,14 +40060,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_3    
++vth0    = nfet_03v3_vth0_3    
 +wvth0   = -1.0069714e-008
 +k1      = 0.79064       
 +k2      = 0.0051958286  
@@ -40089,7 +40089,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -40139,7 +40139,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -40191,9 +40191,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -40223,7 +40223,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.4  nmos
+.model  nfet_03v3.4  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -40245,8 +40245,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -40261,14 +40261,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_4    
++vth0    = nfet_03v3_vth0_4    
 +lvth0   = -4.1979273e-008
 +wvth0   = -2.1596758e-008
 +pvth0   = 2.0029964e-015
@@ -40295,7 +40295,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -40368,7 +40368,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -40430,9 +40430,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -40462,7 +40462,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.5  nmos
+.model  nfet_03v3.5  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -40484,8 +40484,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -40500,14 +40500,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_5    
++vth0    = nfet_03v3_vth0_5    
 +lvth0   = -1.7716408e-008
 +wvth0   = -1.0974289e-008
 +pvth0   = -3.3082384e-015
@@ -40536,7 +40536,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -40608,7 +40608,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -40673,9 +40673,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -40705,7 +40705,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.6  nmos
+.model  nfet_03v3.6  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -40727,8 +40727,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -40743,14 +40743,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_6    
++vth0    = nfet_03v3_vth0_6    
 +lvth0   = 1.325026e-008 
 +wvth0   = -4.067414e-009
 +pvth0   = -1.1596488e-014
@@ -40779,7 +40779,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -40844,7 +40844,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -40911,9 +40911,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -40943,7 +40943,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.7  nmos
+.model  nfet_03v3.7  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -40965,8 +40965,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -40981,14 +40981,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_7    
++vth0    = nfet_03v3_vth0_7    
 +wvth0   = -5.2270629e-009
 +k1      = 0.79064       
 +k2      = -0.00618726   
@@ -41010,7 +41010,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -41058,7 +41058,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -41108,9 +41108,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -41140,7 +41140,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.8  nmos
+.model  nfet_03v3.8  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -41162,8 +41162,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -41178,14 +41178,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_8    
++vth0    = nfet_03v3_vth0_8    
 +lvth0   = -5.5747725e-008
 +wvth0   = -5.7737207e-008
 +pvth0   = 1.824977e-014 
@@ -41214,7 +41214,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -41285,7 +41285,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -41354,9 +41354,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -41386,7 +41386,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.9  nmos
+.model  nfet_03v3.9  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -41408,8 +41408,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -41424,14 +41424,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_9    
++vth0    = nfet_03v3_vth0_9    
 +lvth0   = -9.953513e-009
 +wvth0   = 3.6992425e-009
 +pvth0   = -1.2468455e-014
@@ -41457,7 +41457,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -41526,7 +41526,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -41589,9 +41589,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -41621,7 +41621,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.10  nmos
+.model  nfet_03v3.10  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -41643,8 +41643,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -41659,14 +41659,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_10    
++vth0    = nfet_03v3_vth0_10    
 +lvth0   = 7.3817355e-009
 +wvth0   = -2.7981116e-009
 +pvth0   = -4.6716298e-015
@@ -41693,7 +41693,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -41760,7 +41760,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -41834,9 +41834,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -41866,7 +41866,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.11  nmos
+.model  nfet_03v3.11  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -41888,8 +41888,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -41904,14 +41904,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_11    
++vth0    = nfet_03v3_vth0_11    
 +wvth0   = -3.2652745e-009
 +k1      = 0.79290818    
 +wk1     = -2.6764545e-009
@@ -41933,7 +41933,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -41981,7 +41981,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -42034,9 +42034,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -42066,7 +42066,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.12  nmos
+.model  nfet_03v3.12  nmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -42088,8 +42088,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -42104,14 +42104,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 3e-008        
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_12    
++vth0    = nfet_03v3_vth0_12    
 +lvth0   = -5.3919091e-008
 +k1      = 0.95164273    
 +lk1     = -9.6116364e-008
@@ -42134,7 +42134,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -42191,7 +42191,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -42244,9 +42244,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -42276,7 +42276,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.13  nmos
+.model  nfet_03v3.13  nmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -42298,8 +42298,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -42314,14 +42314,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_13    
++vth0    = nfet_03v3_vth0_13    
 +lvth0   = -1.1202857e-008
 +k1      = 0.75941       
 +k2      = 0.016542914   
@@ -42343,7 +42343,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -42395,7 +42395,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -42446,9 +42446,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -42478,7 +42478,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.14  nmos
+.model  nfet_03v3.14  nmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -42500,8 +42500,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -42516,14 +42516,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 0             
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_14    
++vth0    = nfet_03v3_vth0_14    
 +lvth0   = 6.9136364e-009
 +k1      = 0.79717136    
 +lk1     = -4.5313636e-008
@@ -42546,7 +42546,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -42599,7 +42599,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -42654,9 +42654,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -42686,7 +42686,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  nmos_3p3.15  nmos
+.model  nfet_03v3.15  nmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -42708,8 +42708,8 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = nmos_3p3_tox     
-+toxp    = nmos_3p3_tox     
++toxe    = nfet_03v3_tox     
++toxp    = nfet_03v3_tox     
 +toxm    = 8e-009        
 +epsrox  = 3.9           
 +wint    = 1e-008        
@@ -42724,14 +42724,14 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = nmos_3p3_xl        
-+xw      = nmos_3p3_xw        
++xl      = nfet_03v3_xl        
++xw      = nfet_03v3_xw        
 +dlc     = 3e-008        
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 8e-009        
 +dlcig   = 1.5e-007      
-+vth0    = nmos_3p3_vth0_15    
++vth0    = nfet_03v3_vth0_15    
 +k1      = 0.79264       
 +k2      = -0.0076575    
 +k3      = 0             
@@ -42751,7 +42751,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 1.1e-007      
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = nmos_3p3_xj    
++xj      = nfet_03v3_xj    
 +ngate   = 6e+019        
 +ndep    = 3e+017        
 +nsd     = 1e+020        
@@ -42793,7 +42793,7 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = nmos_3p3_rdsw        
++rdsw    = nfet_03v3_rdsw        
 +rdswmin = 50            
 +rdwmin  = 0             
 +rswmin  = 0             
@@ -42839,9 +42839,9 @@ m0 d1 g s1 b nmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 0.95          
-+noia    = nmos_3p3_noia  
-+noib    = nmos_3p3_noib  
-+noic    = nmos_3p3_noic  
++noia    = nfet_03v3_noia  
++noib    = nfet_03v3_noib  
++noic    = nfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 2.2959e-007   
 +jsws    = 2.1207e-013   
@@ -42917,17 +42917,17 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 *-------------------
 .ends nplus_u_m1
 
-.endl nmos_3p3_stat
+.endl nfet_03v3_stat
 *
 *
 ***************************************************************************************************
 * 3.3V PMOS statistical Models
 ***************************************************************************************************
 *
-.lib pmos_3p3_stat
+.lib pfet_03v3_stat
 
 
-.subckt pmos_3p3_sab d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_03v3_dss d g s b w=10u l=0.28u par=1 s_sab=0.48u d_sab=1.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.00666  
@@ -42948,12 +42948,12 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 
 xr1 d d1 b pplus_u_m1 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m1 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
+m0 d1 g s1 b pfet_03v3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=sa sb=sb sd=sd
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model  pmos_3p3.0  pmos
+.model  pfet_03v3.0  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -42975,8 +42975,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -42991,14 +42991,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_0    
++vth0    = pfet_03v3_vth0_0    
 +lvth0   = -7.6827273e-009
 +wvth0   = 4.2938493e-009
 +pvth0   = 2.3570182e-015
@@ -43027,7 +43027,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -43097,7 +43097,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -43158,9 +43158,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -43199,7 +43199,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.1  pmos
+.model  pfet_03v3.1  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -43221,8 +43221,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -43237,14 +43237,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_1    
++vth0    = pfet_03v3_vth0_1    
 +lvth0   = 8.0902041e-009
 +wvth0   = 5.9668408e-009
 +pvth0   = 1.5205225e-015
@@ -43273,7 +43273,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -43342,7 +43342,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -43400,9 +43400,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -43441,7 +43441,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.2  pmos
+.model  pfet_03v3.2  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -43463,8 +43463,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -43479,14 +43479,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_2    
++vth0    = pfet_03v3_vth0_2    
 +lvth0   = -9.5551948e-009
 +wvth0   = 3.6783584e-009
 +pvth0   = 4.2667013e-015
@@ -43515,7 +43515,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -43586,7 +43586,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -43646,9 +43646,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -43687,7 +43687,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.3  pmos
+.model  pfet_03v3.3  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -43709,8 +43709,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -43725,14 +43725,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_3    
++vth0    = pfet_03v3_vth0_3    
 +wvth0   = 4.1050286e-009
 +k1      = 0.95512857    
 +wk1     = 2.6921143e-008
@@ -43755,7 +43755,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -43805,7 +43805,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -43853,9 +43853,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -43894,7 +43894,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.4  pmos
+.model  pfet_03v3.4  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -43916,8 +43916,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -43932,14 +43932,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_4    
++vth0    = pfet_03v3_vth0_4    
 +lvth0   = -2.1407273e-009
 +wvth0   = 1.4897689e-008
 +pvth0   = -5.2482182e-016
@@ -43966,7 +43966,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -44033,7 +44033,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -44094,9 +44094,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -44135,7 +44135,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.5  pmos
+.model  pfet_03v3.5  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -44157,8 +44157,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -44173,14 +44173,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_5    
++vth0    = pfet_03v3_vth0_5    
 +lvth0   = -3.242449e-010
 +wvth0   = 2.0559739e-009
 +pvth0   = 5.8960359e-015
@@ -44207,7 +44207,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -44276,7 +44276,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -44334,9 +44334,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -44375,7 +44375,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.6  pmos
+.model  pfet_03v3.6  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -44397,8 +44397,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -44413,14 +44413,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_6    
++vth0    = pfet_03v3_vth0_6    
 +lvth0   = -1.3737662e-009
 +wvth0   = 6.9590384e-009
 +pvth0   = 1.2358442e-017
@@ -44447,7 +44447,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -44514,7 +44514,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -44577,9 +44577,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -44618,7 +44618,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.7  pmos
+.model  pfet_03v3.7  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -44640,8 +44640,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -44656,14 +44656,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_7    
++vth0    = pfet_03v3_vth0_7    
 +wvth0   = 6.9602743e-009
 +k1      = 1.0069        
 +k2      = -0.0273714    
@@ -44685,7 +44685,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -44734,7 +44734,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -44782,9 +44782,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -44823,7 +44823,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.8  pmos
+.model  pfet_03v3.8  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -44845,8 +44845,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -44861,14 +44861,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_8    
++vth0    = pfet_03v3_vth0_8    
 +lvth0   = -8.7733719e-009
 +wvth0   = 4.2305517e-009
 +pvth0   = 7.5670046e-015
@@ -44895,7 +44895,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -44962,7 +44962,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -45026,9 +45026,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -45067,7 +45067,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.9  pmos
+.model  pfet_03v3.9  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -45089,8 +45089,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -45105,14 +45105,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_9    
++vth0    = pfet_03v3_vth0_9    
 +lvth0   = -7.1445584e-009
 +wvth0   = -9.069076e-009
 +pvth0   = 1.4216818e-014
@@ -45139,7 +45139,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -45210,7 +45210,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -45271,9 +45271,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -45312,7 +45312,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.10  pmos
+.model  pfet_03v3.10  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -45334,8 +45334,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -45350,14 +45350,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_10    
++vth0    = pfet_03v3_vth0_10    
 +lvth0   = -4.4690083e-009
 +wvth0   = -3.7885537e-010
 +pvth0   = 3.7885537e-015
@@ -45384,7 +45384,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -45449,7 +45449,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -45515,9 +45515,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -45556,7 +45556,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.11  pmos
+.model  pfet_03v3.11  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -45578,8 +45578,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -45594,14 +45594,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_11    
++vth0    = pfet_03v3_vth0_11    
 +k1      = 1.0069        
 +k2      = -0.035641955  
 +wk2     = 3.9173646e-009
@@ -45622,7 +45622,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -45669,7 +45669,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -45717,9 +45717,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -45758,7 +45758,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.12  pmos
+.model  pfet_03v3.12  pmos
 +level = 54
 +lmin    = 2.8e-007      
 +lmax    = 5e-007        
@@ -45780,8 +45780,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -45796,14 +45796,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_12    
++vth0    = pfet_03v3_vth0_12    
 +lvth0   = -8.0181818e-009
 +k1      = 0.99870273    
 +lk1     = -3.5426364e-008
@@ -45826,7 +45826,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -45876,7 +45876,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -45925,9 +45925,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -45966,7 +45966,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.13  pmos
+.model  pfet_03v3.13  pmos
 +level = 54
 +lmin    = 5e-007        
 +lmax    = 1.2e-006      
@@ -45988,8 +45988,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -46004,14 +46004,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_13    
++vth0    = pfet_03v3_vth0_13    
 +lvth0   = -5.7257143e-009
 +k1      = 0.97705       
 +lk1     = -2.46e-008    
@@ -46034,7 +46034,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -46085,7 +46085,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -46134,9 +46134,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -46175,7 +46175,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.14  pmos
+.model  pfet_03v3.14  pmos
 +level = 54
 +lmin    = 1.2e-006      
 +lmax    = 1e-005        
@@ -46197,8 +46197,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -46213,14 +46213,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_14    
++vth0    = pfet_03v3_vth0_14    
 +lvth0   = -4.0909091e-009
 +k1      = 1.0137659     
 +lk1     = -6.8659091e-008
@@ -46243,7 +46243,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -46294,7 +46294,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -46344,9 +46344,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -46385,7 +46385,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +kvth0   = 0             
 +ku0     = 0             
 +kvsat   = 0             
-.model  pmos_3p3.15  pmos
+.model  pfet_03v3.15  pmos
 +level = 54
 +lmin    = 1e-005        
 +lmax    = 5.0001e-005   
@@ -46407,8 +46407,8 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +acnqsmod= 0             
 +trnqsmod= 0             
 +tnom    = 25            
-+toxe    = pmos_3p3_tox   
-+toxp    = pmos_3p3_tox   
++toxe    = pfet_03v3_tox   
++toxp    = pfet_03v3_tox   
 +toxm    = 7.9e-009      
 +epsrox  = 3.9           
 +wint    = -1e-008       
@@ -46423,14 +46423,14 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +wwn     = 1             
 +lwl     = 0             
 +wwl     = 0             
-+xl      = pmos_3p3_xl        
-+xw      = pmos_3p3_xw        
++xl      = pfet_03v3_xl        
++xw      = pfet_03v3_xw        
 +dlc     = -8e-009       
 +dwc     = 0             
 +xpart   = 0             
 +toxref  = 7.9e-009      
 +dlcig   = 1.5e-007      
-+vth0    = pmos_3p3_vth0_15    
++vth0    = pfet_03v3_vth0_15    
 +k1      = 1.0069        
 +k2      = -0.035251     
 +k3      = 0             
@@ -46450,7 +46450,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lpe0    = 3.2493e-008   
 +lpeb    = 0             
 +vbm     = -3            
-+xj      = pmos_3p3_xj     
++xj      = pfet_03v3_xj     
 +ngate   = 6e+019        
 +ndep    = 5.6e+017      
 +nsd     = 1e+020        
@@ -46493,7 +46493,7 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +pditsd  = 0             
 +pditsl  = 0             
 +rsh     = 7             
-+rdsw    = pmos_3p3_rdsw           
++rdsw    = pfet_03v3_rdsw           
 +rdswmin = 20            
 +prwg    = 0             
 +prwb    = 0             
@@ -46536,9 +46536,9 @@ m0 d1 g s1 b pmos_3p3 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +tnoimod = 0             
 +em      = 4.1e+007      
 +ef      = 1.12          
-+noia    = pmos_3p3_noia  
-+noib    = pmos_3p3_noib  
-+noic    = pmos_3p3_noic  
++noia    = pfet_03v3_noia  
++noib    = pfet_03v3_noib  
++noic    = pfet_03v3_noic  
 +ntnoi   = 1             
 +jss     = 1.653e-007    
 +jsws    = 2.1207e-013   
@@ -46620,22 +46620,22 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 .ends pplus_u_m1
 
 
-.endl pmos_3p3_stat
+.endl pfet_03v3_stat
 *
 ***************************************************************************************************
 * 6V native NMOS statistical Models
 ***************************************************************************************************
 *
-.lib nmos_6p0_nat_stat
+.lib nfet_06v0_nvt_stat
 
-*.lib nmos_6p0_nat_t
-.subckt nmos_6p0_nat d g s b w=1e-5 l=1.8e-6 as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0 sa=0 sb=0 nf=1 sd=0 m=1
+*.lib nfet_06v0_nvt_t
+.subckt nfet_06v0_nvt d g s b w=1e-5 l=1.8e-6 as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0 sa=0 sb=0 nf=1 sd=0 m=1
 
-m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb=sb nf=nf sd=sd
+m0 d g s b nfet_06v0_nvt w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb=sb nf=nf sd=sd
 
-.ends nmos_6p0_nat
+.ends nfet_06v0_nvt
 
-.model  nmos_6p0_nat.0  nmos
+.model  nfet_06v0_nvt.0  nmos
 +level = 54
 **************************************************************
 *               MODEL FLAG PARAMETERS 
@@ -46651,7 +46651,7 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 **************************************************************
 *               GENERAL MODEL PARAMETERS 
 **************************************************************
-+tnom    = 25              toxe    = nmos_6p0_nat_tox    toxp    = '8e-10+nmos_6p0_nat_tox' 
++tnom    = 25              toxe    = nfet_06v0_nvt_tox    toxp    = '8e-10+nfet_06v0_nvt_tox' 
 +toxm    = 1.52e-008       epsrox  = 3.9             toxref  = 1.52e-008     
 +wint    = 1e-009          lint    = 1e-007          ll      = 0             
 +wl      = 0               lln     = 1               wln     = 1             
@@ -46659,12 +46659,12 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 +wwn     = 1               lwl     = 0               wwl     = 0             
 +llc     = 0               wlc     = 0               lwc     = 0             
 +wwc     = 0               lwlc    = 0               wwlc    = 0             
-+xl      = nmos_6p0_nat_xl     xw      = nmos_6p0_nat_xw     dlc     = 0             
++xl      = nfet_06v0_nvt_xl     xw      = nfet_06v0_nvt_xw     dlc     = 0             
 +dwc     = 0               dlcig   = 0               xpart   = 0             
 **************************************************************
 *               DC PARAMETERS 
 **************************************************************
-+vth0    = nmos_6p0_nat_vth0   lvth0   = -0.088           k1      = 0.165         
++vth0    = nfet_06v0_nvt_vth0   lvth0   = -0.088           k1      = 0.165         
 +k2      = -0.001          k3      = -0.6            k3b     = -0.6          
 +w0      = 1e-010          dvt0    = 2.2             dvt1    = 0.53          
 +dvt2    = -0.032          dvt0w   = 0               dvt1w   = 5300000       
@@ -46672,7 +46672,7 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 +voffl   = 0               dvtp0   = 1e-008          dvtp1   = 0             
 +lambda  = 0               vtl     = 200000          xn      = 3             
 +lpe0    = 1e-007          lpeb    = 0               vbm     = -3            
-+xj      = nmos_6p0_nat_xj   ngate   = 1e+020          ndep    = 1.7e+017      
++xj      = nfet_06v0_nvt_xj   ngate   = 1e+020          ndep    = 1.7e+017      
 +nsd     = 1e+020          phin    = 0.5             cdsc    = 0.00024       
 +cdscb   = 0               cdscd   = 0               cit     = 0             
 +voff    = -0.06           ud1     = 0               up      = 0             
@@ -46688,7 +46688,7 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 +drout   = 0.16            pvag    = 1               delta   = 0.005         
 +pscbe1  = 5e+009          pscbe2  = 5e-006          fprout  = 65            
 +pdits   = 0               pditsd  = 0               pditsl  = 0             
-+rsh     = 7               rdsw    = nmos_6p0_nat_rdsw   rsw     = 100           
++rsh     = 7               rdsw    = nfet_06v0_nvt_rdsw   rsw     = 100           
 +rdw     = 100             rdswmin = 0               rdwmin  = 0             
 +rswmin  = 0               prwg    = 1               prwb    = 0             
 +wr      = 1               alpha0  = 1.36e-008       alpha1  = 1e-005        
@@ -46721,8 +46721,8 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 *               NOISE PARAMETERS 
 **************************************************************
 +fnoimod = 1               tnoimod = 0               em      = 4.1e+007      
-+ef      = 1               noia    = nmos_6p0_nat_noia   noib    = nmos_6p0_nat_noib    
-+noic    = nmos_6p0_nat_noic   ntnoi   = 1               lintnoi = 0             
++ef      = 1               noia    = nfet_06v0_nvt_noia   noib    = nfet_06v0_nvt_noib    
++noic    = nfet_06v0_nvt_noic   ntnoi   = 1               lintnoi = 0             
 **************************************************************
 *               DIODE PARAMETERS 
 **************************************************************
@@ -46776,16 +46776,16 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 +pku0    = 0               llodku0 = 0               wlodku0 = 0             
 +kvsat   = 0               steta0  = 0               tku0    = 0             
 
-.endl nmos_6p0_nat_stat
+.endl nfet_06v0_nvt_stat
 *
 ***************************************************************************************************
 * 6V PMOS statistical Models
 ***************************************************************************************************
 *
-.lib pmos_6p0_stat
+.lib pfet_06v0_stat
 
 
-.subckt pmos_6p0_sab d g s b w=10u l=0.5u par=1 s_sab=0.28u d_sab=2.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
+.subckt pfet_06v0_dss d g s b w=10u l=0.5u par=1 s_sab=0.28u d_sab=2.78u as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 dtemp=0 nf=1 sa=0 sb=0 sd=0 m=1
 
 .param
 + par_vth=0.01051 
@@ -46806,12 +46806,12 @@ m0 d g s b nmos_6p0_nat w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs sa=sa sb
 
 xr1 d d1 b pplus_u_m2 wr='w' lr='(d_sab==0) ? 1e-15 : d_sab' 
 xr2 s s1 b pplus_u_m2 wr='w' lr='(s_sab==0) ? 1e-15 : s_sab' 
-m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=0 sb=0 sd=0
+m0 d1 g s1 b pfet_06v0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf sa=0 sb=0 sd=0
 +delvto='mis_vth*sw_stat_mismatch' 
 .ends
 
 
-.model pmos_6p0.0 pmos
+.model pfet_06v0.0 pmos
 ***** Flag Parameter ***
 +level = 54                    version = 4.6                 binunit = 1                   
 +paramchk = 1                  mobmod = 0                    capmod = 2                    
@@ -46823,7 +46823,7 @@ m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +lmin = 0.5e-6                lmax = 50.01e-6               wmin = 0.3e-6                      
 +wmax = 100.01e-6                      
 ***** Process Parameter ***
-+epsrox = 3.9                  toxe = pmos_6p0_tox           xj = pmos_6p0_xj              
++epsrox = 3.9                  toxe = pfet_06v0_tox           xj = pfet_06v0_xj              
 +ndep = 1.7E17                 ngate = 3.6E19                nsd = 6E16                    
 +rsh = 7                       rshg = 0.1                    phin = 0                      
 +lphin = 0.1408                
@@ -46832,10 +46832,10 @@ m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +ww = -1.37E-14                wwn = 1                       wwl = 3.04E-22                
 +lint = 6.7E-8                 ll = -5.4E-15                 lln = 1                       
 +lw = 0                        lwn = 1                       lwl = -4.76E-21               
-+dwg = -6.6E-9                 dwb = -3E-9                   xl = pmos_6p0_xl              
-+xw = pmos_6p0_xw         
++dwg = -6.6E-9                 dwb = -3E-9                   xl = pfet_06v0_xl              
++xw = pfet_06v0_xw         
 ***** Vth Related  Parameter ***
-+vth0 = pmos_6p0_vth0          pvth0 = 7.6E-3               
++vth0 = pfet_06v0_vth0          pvth0 = 7.6E-3               
 +k1 = 0.9588                   k2 = 8.936E-3                 vfb = -1
 +k3 = -0.75                    k3b = 1.2104                  w0 = 3.1E-7                   
 +lpe0 = -4.4E-8                lpeb = -5.96E-8               dvtp0 = 0                     
@@ -46848,7 +46848,7 @@ m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +vsat = 8.55E4                 a0 = 0.84                     ags = 0.059                   
 +b0 = 2.625E-8                 b1 = 0                        keta = -8.6016E-5             
 +wketa = 2.772E-3              a1 = 0                        a2 = 1                        
-+rdsw = pmos_6p0_rdsw          wrdsw = 213.9                 prdsw = -120                  
++rdsw = pfet_06v0_rdsw          wrdsw = 213.9                 prdsw = -120                  
 +rdswmin = 100                 prwb = 0.569552               pprwb = -0.052                
 +prwg = 0.0432                 wr = 1                        
 ***** Subthreshold Related Parameter ***
@@ -46866,8 +46866,8 @@ m0 d1 g s1 b pmos_6p0 w='w' l='l' as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs nf=nf 
 +alpha0 = 9.6E-7               alpha1 = 51.5                 beta0 = 50.8                  
 +wbeta0 = 0.22                 pbeta0 = 0.14                 
 ***** Noise Parameters ***
-+ef      = 1.1                 noia    = pmos_6p0_noia        
-+noib    = pmos_6p0_noib       noic    = pmos_6p0_noic                  
++ef      = 1.1                 noia    = pfet_06v0_noia        
++noib    = pfet_06v0_noib       noic    = pfet_06v0_noic                  
 ***** Capacitance Parameter ***
 +xpart = 1                     cgso = 7.71E-11               cgdo = 7.71E-11               
 +cgbo = 1E-13                  ckappas = 0.6                 ckappad = 0.6                 
@@ -46943,7 +46943,7 @@ rb  1 2 r='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2)
 .ends pplus_u_m2
 
 
-.endl pmos_6p0_stat
+.endl pfet_06v0_stat
 *
 
 .LIB efuse
@@ -46981,7 +46981,7 @@ rfuse  in out  r='200*(1-pblow) + 900*pblow'
 .ENDL efuse
 
 .lib fets_mm
-.subckt nmos_3p3 d g s b w=1e-5 l=2.8e-7
+.subckt nfet_03v3 d g s b w=1e-5 l=2.8e-7
 + as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0
 + sa=0 sb=0 nf=1 sd=0 m=1
 
@@ -47002,11 +47002,11 @@ rfuse  in out  r='200*(1-pblow) + 900*pblow'
 + var_vth='0.7071*par_vth* 1e-06 / p_sqrtarea'
 + mis_vth=agauss(0,var_vth,1)
 
-m0 d g s b nmos_3p3 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
+m0 d g s b nfet_03v3 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
 +delvto='mis_vth*sw_stat_mismatch'  sa=sa sb=sb nf=nf sd=sd
-.ends nmos_3p3
+.ends nfet_03v3
 *------------------------------------------------------------------------
-.subckt pmos_3p3 d g s b w=1e-5 l=2.8e-7
+.subckt pfet_03v3 d g s b w=1e-5 l=2.8e-7
 + as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0
 + sa=0 sb=0 nf=1 sd=0 m=1
 
@@ -47027,11 +47027,11 @@ m0 d g s b nmos_3p3 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs
 + var_vth='0.7071*par_vth* 1e-06 / p_sqrtarea'
 + mis_vth=agauss(0,var_vth,1)
 
-m0 d g s b pmos_3p3 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
+m0 d g s b pfet_03v3 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
 +delvto='mis_vth*sw_stat_mismatch'  sa=sa sb=sb nf=nf sd=sd
-.ends pmos_3p3
+.ends pfet_03v3
 *------------------------------------------------------------------------
-.subckt nmos_6p0 d g s b w=1e-5 l=7e-7
+.subckt nfet_06v0 d g s b w=1e-5 l=7e-7
 + as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0
 + sa=0 sb=0 nf=1 sd=0 m=1
 
@@ -47052,11 +47052,11 @@ m0 d g s b pmos_3p3 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs
 + var_vth='0.7071*par_vth* 1e-06 / p_sqrtarea'
 + mis_vth=agauss(0,var_vth,1)
 
-m0 d g s b nmos_6p0 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
+m0 d g s b nfet_06v0 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
 +delvto='mis_vth*sw_stat_mismatch'  sa=sa sb=sb nf=nf sd=sd
-.ends nmos_6p0
+.ends nfet_06v0
 *------------------------------------------------------------------------
-.subckt pmos_6p0 d g s b w=1e-5 l=5e-7
+.subckt pfet_06v0 d g s b w=1e-5 l=5e-7
 + as=0 ad=0 ps=0 pd=0 nrd=0 nrs=0 par=1 dtemp=0
 + sa=0 sb=0 nf=1 sd=0 m=1
 
@@ -47077,9 +47077,9 @@ m0 d g s b nmos_6p0 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs
 + var_vth='0.7071*par_vth* 1e-06 / p_sqrtarea'
 + mis_vth=agauss(0,var_vth,1)
 
-m0 d g s b pmos_6p0 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
+m0 d g s b pfet_06v0 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs 
 +delvto='mis_vth*sw_stat_mismatch'  sa=sa sb=sb nf=nf sd=sd
-.ends pmos_6p0
+.ends pfet_06v0
 *------------------------------------------------------------------------
 
 .endl fets_mm
@@ -47282,17 +47282,17 @@ m0 d g s b pmos_6p0 w=w l=l as=as ad=ad ps=ps pd=pd nrd=nrd nrs=nrs
 
 .lib bjt_mc
 
-.subckt vpnp_0p42x10 c b e par=1 dtemp=0
+.subckt pnp_10p00x00p42 c b e par=1 dtemp=0
 
 .param
-+mis_is_vpnp_0p42x10=agauss(0,0.0015,1)
-+mis_bf_vpnp_0p42x10=agauss(0,0.01088,1)
++mis_is_pnp_10p00x00p42=agauss(0,0.0015,1)
++mis_bf_pnp_10p00x00p42=agauss(0,0.01088,1)
 
-+isa_mis_vpnp_0p42x10= 'mis_is_vpnp_0p42x10*sw_stat_mismatch / sqrt(par)'
-+bf_mis_vpnp_0p42x10= 'mis_bf_vpnp_0p42x10*sw_stat_mismatch / sqrt(par)'
++isa_mis_pnp_10p00x00p42= 'mis_is_pnp_10p00x00p42*sw_stat_mismatch / sqrt(par)'
++bf_mis_pnp_10p00x00p42= 'mis_bf_pnp_10p00x00p42*sw_stat_mismatch / sqrt(par)'
 
-q0 c b e  vpnp_0p42x10  dtemp=dtemp
-.model  vpnp_0p42x10  pnp  
+q0 c b e  pnp_10p00x00p42  dtemp=dtemp
+.model  pnp_10p00x00p42  pnp  
 +tref    = 25              	level = 1
 +cjc     = '2.04e-014*cjca*(1 + mc_xcjc_vpnp*sw_stat_global)' 	cje     = '6.88e-015*cjea*(1 + mc_xcje_vpnp*sw_stat_global)' 	cjs     = 0               fc      = 0.5           
 +mjc     = 0.22711         	mje     = 0.14469         	mjs     = 0.5             vjc     = 0.43905       
@@ -47300,8 +47300,8 @@ q0 c b e  vpnp_0p42x10  dtemp=dtemp
 +cbep    = 0               	ccsp    = 0               	itf     = 0.1             ptf     = 0             
 +tf      = 1e-010          	tr      = 0               	vtf     = 10              xtf     = 1             
 +af      = 1               	kf      = 0             
-+is      = '9e-019*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + isa_mis_vpnp_0p42x10)'    	rb      = '41*rba*(1 + mc_xrb_vpnp*sw_stat_global)'        	re      = '1*rea*(1 + mc_xre_vpnp*sw_stat_global)'         irb     = 0.1           
-+rc      = '10*rca*(1 + mc_xrc_vpnp*sw_stat_global)'        	rbm     = '10*rbma'       	bf      = '1.69*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + bf_mis_vpnp_0p42x10)'      nf      = 1             
++is      = '9e-019*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + isa_mis_pnp_10p00x00p42)'    	rb      = '41*rba*(1 + mc_xrb_vpnp*sw_stat_global)'        	re      = '1*rea*(1 + mc_xre_vpnp*sw_stat_global)'         irb     = 0.1           
++rc      = '10*rca*(1 + mc_xrc_vpnp*sw_stat_global)'        	rbm     = '10*rbma'       	bf      = '1.69*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + bf_mis_pnp_10p00x00p42)'      nf      = 1             
 +vaf     = 80              	ikf     = 0.00063375      	ise     = 2.7e-016        ne      = 1.64          
 +br      = 0.0036          	nr      = 1               	var     = 23              ikr     = 0.1           
 +nkf     = 0.4             	isc     = 1e-018          	nc      = 2             
@@ -47309,17 +47309,17 @@ q0 c b e  vpnp_0p42x10  dtemp=dtemp
 +cte     = 0.001           	tlevc   = 1               	tvjc    = 0.0024779       tvje    = 0.0019314     
 +tbf1    = 0.0061          	tikf1   = -0.0043         	tbf2    = -4.235165e-022
 
-.ends vpnp_0p42x10
+.ends pnp_10p00x00p42
 
-.subckt vpnp_0p42x5 c b e par=1 dtemp=0
+.subckt pnp_05p00x00p42 c b e par=1 dtemp=0
 
 .param
-+mis_is_vpnp_0p42x5=agauss(0,0.0017,1)
-+mis_bf_vpnp_0p42x5=agauss(0,0.0119,1)
-q0 c b e  vpnp_0p42x5  dtemp=dtemp
-.model vpnp_0p42x5 pnp
++mis_is_pnp_05p00x00p42=agauss(0,0.0017,1)
++mis_bf_pnp_05p00x00p42=agauss(0,0.0119,1)
+q0 c b e  pnp_05p00x00p42  dtemp=dtemp
+.model pnp_05p00x00p42 pnp
 +level = 1                     tlevc = 1                     	tref = 25                     
-+is = '4.388E-19*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_vpnp_0p42x5*sw_stat_mismatch / sqrt(par))'    bf = '1.681*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_vpnp_0p42x5*sw_stat_mismatch / sqrt(par))'    nf = 1                        
++is = '4.388E-19*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_pnp_05p00x00p42*sw_stat_mismatch / sqrt(par))'    bf = '1.681*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_pnp_05p00x00p42*sw_stat_mismatch / sqrt(par))'    nf = 1                        
 +vaf = 180                     ikf = 2.4777E-4               	nkf = 0.4                     
 +ise = 1.2124E-16              ne = 1.64                     	br = 1.9872E-3                
 +nr = 1                        var = 23                      	ikr = 0.1                     
@@ -47338,18 +47338,18 @@ q0 c b e  vpnp_0p42x5  dtemp=dtemp
 +cte = 1E-3                    ctc = 2.8626E-3               	tvje = 1.9314E-3              
 +tvjc = 2.4779E-3              
 +kf = 0                        af = 1    
-.ends vpnp_0p42x5
+.ends pnp_05p00x00p42
 
 
-.subckt vpnp_10x10 c b e par=1 dtemp=0
+.subckt pnp_10p00x10p00 c b e par=1 dtemp=0
 
 .param
-+mis_is_vpnp_10x10=agauss(0,0.00077,1)
-+mis_bf_vpnp_10x10=agauss(0,0.0013,1)
-q0 c b e  vpnp_10x10  dtemp=dtemp
-.model vpnp_10x10 pnp
++mis_is_pnp_10p00x10p00=agauss(0,0.00077,1)
++mis_bf_pnp_10p00x10p00=agauss(0,0.0013,1)
+q0 c b e  pnp_10p00x10p00  dtemp=dtemp
+.model pnp_10p00x10p00 pnp
 +level = 1                     tlevc = 1                     	tref = 25                     
-+is = '1.249175E-17*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_vpnp_10x10*sw_stat_mismatch / sqrt(par))'       bf = '1.7*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_vpnp_10x10*sw_stat_mismatch / sqrt(par))'                	nf = 1                        
++is = '1.249175E-17*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_pnp_10p00x10p00*sw_stat_mismatch / sqrt(par))'       bf = '1.7*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_pnp_10p00x10p00*sw_stat_mismatch / sqrt(par))'                	nf = 1                        
 +vaf = 206.4                   ikf = 2.610625E-3             	nkf = 0.4                     
 +ise = 2.7E-16                 ne = 1.64                     	br = 0.017038                 
 +nr = 1                        var = 23                      	ikr = 0.1                     
@@ -47368,18 +47368,18 @@ q0 c b e  vpnp_10x10  dtemp=dtemp
 +cte = 1E-3                    ctc = 2.8626E-3               	tvje = 1.9314E-3              
 +tvjc = 2.4779E-3              
 +kf = 0                        af = 1     
-.ends vpnp_10x10
+.ends pnp_10p00x10p00
 
-.subckt vpnp_5x5 c b e par=1 dtemp=0
+.subckt pnp_05p00x05p00 c b e par=1 dtemp=0
 
 .param
-+mis_is_vpnp_5x5=agauss(0,0.00052,1)
-+mis_bf_vpnp_5x5=agauss(0,0.0031,1)
++mis_is_pnp_05p00x05p00=agauss(0,0.00052,1)
++mis_bf_pnp_05p00x05p00=agauss(0,0.0031,1)
 
-q0 c b e  vpnp_5x5  dtemp=dtemp
-.model vpnp_5x5 pnp
+q0 c b e  pnp_05p00x05p00  dtemp=dtemp
+.model pnp_05p00x05p00 pnp
 +level = 1                     tlevc = 1                     	tref = 25                     
-+is = '3.403E-18*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_vpnp_5x5*sw_stat_mismatch / sqrt(par))'          bf = '1.65*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 +mis_bf_vpnp_5x5*sw_stat_mismatch / sqrt(par))'               	nf = 1                        
++is = '3.403E-18*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_pnp_05p00x05p00*sw_stat_mismatch / sqrt(par))'          bf = '1.65*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 +mis_bf_pnp_05p00x05p00*sw_stat_mismatch / sqrt(par))'               	nf = 1                        
 +vaf = 208.8                   ikf = 1.025275E-3             	nkf = 0.4                     
 +ise = 2.7E-16                 ne = 1.64                     	br = 8.372E-3                 
 +nr = 1                        var = 27.37                   	ikr = 0.1                     
@@ -47398,12 +47398,12 @@ q0 c b e  vpnp_5x5  dtemp=dtemp
 +cte = 1E-3                    ctc = 2.8626E-3               	tvje = 1.9314E-3              
 +tvjc = 2.4779E-3              
 +kf = 0                        af = 1     
-.ends vpnp_5x5
+.ends pnp_05p00x05p00
 
-.subckt vnpn_10x10  c b e s par=1 dtemp=0
+.subckt npn_10p00x10p00  c b e s par=1 dtemp=0
 
-q0 c b e s  vnpn_10x10  dtemp=dtemp
-.model  vnpn_10x10  npn  level = 1
+q0 c b e s  npn_10p00x10p00  dtemp=dtemp
+.model  npn_10p00x10p00  npn  level = 1
 **************************************************************
 *               GENERAL PARAMETERS 
 **************************************************************
@@ -47434,12 +47434,12 @@ q0 c b e s  vnpn_10x10  dtemp=dtemp
 +tnr1    = 0.0001584       tne1    = 0.00047174      tbf1    = 0.00484         tbr1    = 0.0003808     
 +tikf1   = -0.0053169      tre1    = 0.002           tbf2    = 3.705e-006 
 
-.ends vnpn_10x10
+.ends npn_10p00x10p00
 
-.subckt vnpn_5x5  c b e s par=1 dtemp=0
+.subckt npn_05p00x05p00  c b e s par=1 dtemp=0
 
-q0 c b e s  vnpn_5x5  dtemp=dtemp
-.model  vnpn_5x5  npn  level = 1
+q0 c b e s  npn_05p00x05p00  dtemp=dtemp
+.model  npn_05p00x05p00  npn  level = 1
 **************************************************************
 *               GENERAL PARAMETERS 
 **************************************************************
@@ -47469,13 +47469,13 @@ q0 c b e s  vnpn_5x5  dtemp=dtemp
 +xtb     = 0               xti     = 3               eg      = 1.17            tnf1    = 6e-005        
 +tnr1    = 0.0001071       tne1    = 0.0005          tbf1    = 0.0050844       tbr1    = 0.00045       
 +tikf1   = -0.005          tre1    = 0.001           tbf2    = 4.3586e-006
-.ends vnpn_5x5
+.ends npn_05p00x05p00
 
-.subckt vnpn_0p54x16  c b e s par=1 dtemp=0
+.subckt npn_00p54x16p00  c b e s par=1 dtemp=0
 
 
-q0 c b e s  vnpn_0p54x16  dtemp=dtemp
-.model  vnpn_0p54x16  npn  level = 1
+q0 c b e s  npn_00p54x16p00  dtemp=dtemp
+.model  npn_00p54x16p00  npn  level = 1
 **************************************************************
 *               GENERAL PARAMETERS 
 **************************************************************
@@ -47505,13 +47505,13 @@ q0 c b e s  vnpn_0p54x16  dtemp=dtemp
 +xtb     = 0               xti     = 3               eg      = 1.17            tnf1    = 5.2528e-005   
 +tnr1    = 0.0001          tne1    = 0.00034324      tbf1    = 0.0057737       tbr1    = 0.0007104     
 +tikf1   = -0.003          tre1    = 0.0035596       tbf2    = 2.2189e-006
-.ends vnpn_0p54x16
+.ends npn_00p54x16p00
 
-.subckt vnpn_0p54x8  c b e s par=1 dtemp=0
+.subckt npn_00p54x08p00  c b e s par=1 dtemp=0
 
-q0 c b e s  vnpn_0p54x8  dtemp=dtemp
+q0 c b e s  npn_00p54x08p00  dtemp=dtemp
 
-.model  vnpn_0p54x8  npn  level = 1
+.model  npn_00p54x08p00  npn  level = 1
 **************************************************************
 *               GENERAL PARAMETERS 
 **************************************************************
@@ -47541,13 +47541,13 @@ q0 c b e s  vnpn_0p54x8  dtemp=dtemp
 +xtb     = 0               xti     = 3               eg      = 1.17            tnf1    = 4.56e-005     
 +tnr1    = 0.0001          tne1    = 0.00065         tbf1    = 0.0050727       tbr1    = 0.00085272    
 +tikf1   = -0.003          tre1    = 0.00336         tbf2    = 7.3496e-006
-.ends vnpn_0p54x8
+.ends npn_00p54x08p00
 
-.subckt vnpn_0p54x4  c b e s par=1 dtemp=0
+.subckt npn_00p54x04p00  c b e s par=1 dtemp=0
 
 
-q0 c b e s  vnpn_0p54x4  dtemp=dtemp
-.model  vnpn_0p54x4  npn  level = 1
+q0 c b e s  npn_00p54x04p00  dtemp=dtemp
+.model  npn_00p54x04p00  npn  level = 1
 **************************************************************
 *               GENERAL PARAMETERS 
 **************************************************************
@@ -47577,12 +47577,12 @@ q0 c b e s  vnpn_0p54x4  dtemp=dtemp
 +xtb     = 0               xti     = 3               eg      = 1.17            tnf1    = 5e-005        
 +tnr1    = 0.0001          tne1    = 0.0004          tbf1    = 0.0058206       tbr1    = 0.0009        
 +tbf2    = -6.2e-007
-.ends vnpn_0p54x4
-.subckt vnpn_0p54x2  c b e s par=1 dtemp=0
+.ends npn_00p54x04p00
+.subckt npn_00p54x02p00  c b e s par=1 dtemp=0
 
 
-q0 c b e s  vnpn_0p54x2  dtemp=dtemp
-.model  vnpn_0p54x2  npn  level = 1
+q0 c b e s  npn_00p54x02p00  dtemp=dtemp
+.model  npn_00p54x02p00  npn  level = 1
 **************************************************************
 *               GENERAL PARAMETERS 
 **************************************************************
@@ -47612,7 +47612,7 @@ q0 c b e s  vnpn_0p54x2  dtemp=dtemp
 +xtb     = 0               xti     = 3               eg      = 1.17            tnf1    = 5e-005        
 +tnr1    = 0.0001          tne1    = 0.0005          tbf1    = 0.005536        tbr1    = 0.001         
 +tbf2    = -1.5876e-006
-.ends vnpn_0p54x2
+.ends npn_00p54x02p00
 .endl bjt_mc
 
 .lib mimcap_statistical
@@ -47628,7 +47628,7 @@ q0 c b e s  vnpn_0p54x2  dtemp=dtemp
 + mc_c_cox_1p5fF='mc_c_cox_1p5fF2*sw_stat_global*cap_mc_skew'
 + mc_c_cox_2p0fF='mc_c_cox_2p0fF2*sw_stat_global*cap_mc_skew'
 
-.lib 'sm141064.ngspice' mim_cap
+.lib 'sm141064_mim.ngspice' cap_mim_new
 .endl mimcap_statistical
 
 

--- a/models/ngspice/sm141064_mim.ngspice
+++ b/models/ngspice/sm141064_mim.ngspice
@@ -1,0 +1,274 @@
+* ----------------------------------------------------------------------------------------------------
+.LIB cap_mim_new
+* ----------------------------------------------------------------------------------------------------
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-A [3LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f5_m2m3_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='1.47e-3*mim_corner_1p5fF'
++ c_capsw='3.79e-10*mim_corner_1p5fF'
++ c_tnom=25
++ c_tc1=4.0604E-05
++ c_tc2=-6.90E-08
++ c_vcr1=-4.5152E-05
++ c_vcr2=9.748E-06
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ends cap_mim_1f5_m2m3_noshield
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f0_m2m3_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='0.987e-3*mim_corner_1p0fF'
++ c_capsw='3.3e-10*mim_corner_1p0fF'
++ c_tnom=25
++ c_tc1=1.302e-5
++ c_tc2=-4.93e-9
++ c_vcr1=6.079e-6
++ c_vcr2=1.268e-6
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ends cap_mim_1f0_m2m3_noshield
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_2f0_m2m3_noshield  1 2  c_length=l  c_width=w dtemp=0 par=1
+.param gleak='9.51e-10/5*10000'
+.param c_cox='1.99e-3*mim_corner_2p0fF'
+.param c_capsw='2.383e-10*mim_corner_2p0fF'
+.param c_vcr1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.param c_vcr2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+
+.param c_tnom=25
+.param c_tc1=1.46e-5
+.param c_tc2=-5.55e-8
+.param c_AREA='c_length*c_width'
+.param c_PERI='2*(c_length+c_width)'
+
+.param c_c0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temper +dtemp -c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*
+c_cap 1 2 c='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+r_leak 1 2 r='1/(gleak*c_AREA)' tc1=c_tc1 tc2=c_tc2 dtemp=dtemp
+.ends cap_mim_2f0_m2m3_noshield
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-B [4LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f5_m3m4_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='1.47e-3*mim_corner_1p5fF'
++ c_capsw='3.79e-10*mim_corner_1p5fF'
++ c_tnom=25
++ c_tc1=4.0604E-05
++ c_tc2=-6.90E-08
++ c_vcr1=-4.5152E-05
++ c_vcr2=9.748E-06
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ends cap_mim_1f5_m3m4_noshield
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f0_m3m4_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='0.987e-3*mim_corner_1p0fF'
++ c_capsw='3.3e-10*mim_corner_1p0fF'
++ c_tnom=25
++ c_tc1=1.302e-5
++ c_tc2=-4.93e-9
++ c_vcr1=6.079e-6
++ c_vcr2=1.268e-6
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ends cap_mim_1f0_m3m4_noshield
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_2f0_m3m4_noshield  1 2  c_length=l  c_width=w dtemp=0 par=1
+.param gleak='9.51e-10/5*10000'
+.param c_cox='1.99e-3*mim_corner_2p0fF'
+.param c_capsw='2.383e-10*mim_corner_2p0fF'
+.param c_vcr1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.param c_vcr2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+
+.param c_tnom=25
+.param c_tc1=1.46e-5
+.param c_tc2=-5.55e-8
+.param c_AREA='c_length*c_width'
+.param c_PERI='2*(c_length+c_width)'
+
+.param c_c0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temper +dtemp -c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*
+c_cap 1 2 c='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+r_leak 1 2 r='1/(gleak*c_AREA)' tc1=c_tc1 tc2=c_tc2 dtemp=dtemp
+.ends cap_mim_2f0_m3m4_noshield
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-B [5LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f5_m4m5_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='1.47e-3*mim_corner_1p5fF'
++ c_capsw='3.79e-10*mim_corner_1p5fF'
++ c_tnom=25
++ c_tc1=4.0604E-05
++ c_tc2=-6.90E-08
++ c_vcr1=-4.5152E-05
++ c_vcr2=9.748E-06
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ends cap_mim_1f5_m4m5_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f0_m4m5_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='0.987e-3*mim_corner_1p0fF'
++ c_capsw='3.3e-10*mim_corner_1p0fF'
++ c_tnom=25
++ c_tc1=1.302e-5
++ c_tc2=-4.93e-9
++ c_vcr1=6.079e-6
++ c_vcr2=1.268e-6
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ends cap_mim_1f0_m4m5_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_2f0_m4m5_noshield  1 2  c_length=l  c_width=w dtemp=0 par=1
+.param gleak='9.51e-10/5*10000'
+.param c_cox='1.99e-3*mim_corner_2p0fF'
+.param c_capsw='2.383e-10*mim_corner_2p0fF'
+.param c_vcr1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.param c_vcr2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+
+.param c_tnom=25
+.param c_tc1=1.46e-5
+.param c_tc2=-5.55e-8
+.param c_AREA='c_length*c_width'
+.param c_PERI='2*(c_length+c_width)'
+
+.param c_c0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temper +dtemp -c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*
+c_cap 1 2 c='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+r_leak 1 2 r='1/(gleak*c_AREA)' tc1=c_tc1 tc2=c_tc2 dtemp=dtemp
+.ends cap_mim_2f0_m4m5_noshield
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-B [6LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f5_m5m6_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='1.47e-3*mim_corner_1p5fF'
++ c_capsw='3.79e-10*mim_corner_1p5fF'
++ c_tnom=25
++ c_tc1=4.0604E-05
++ c_tc2=-6.90E-08
++ c_vcr1=-4.5152E-05
++ c_vcr2=9.748E-06
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ends cap_mim_1f5_m5m6_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_1f0_m5m6_noshield 1 2  c_length=l c_width=w dtemp=0 par=1
+.param
++ c_cox='0.987e-3*mim_corner_1p0fF'
++ c_capsw='3.3e-10*mim_corner_1p0fF'
++ c_tnom=25
++ c_tc1=1.302e-5
++ c_tc2=-4.93e-9
++ c_vcr1=6.079e-6
++ c_vcr2=1.268e-6
++ c_area='c_length*c_width'
++ c_peri='2*(c_length+c_width)'
++ c_c0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temper+dtemp-c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+c_cap 1 2 c='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ends cap_mim_1f0_m5m6_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.subckt cap_mim_2f0_m5m6_noshield  1 2  c_length=l  c_width=w dtemp=0 par=1
+.param gleak='9.51e-10/5*10000'
+.param c_cox='1.99e-3*mim_corner_2p0fF'
+.param c_capsw='2.383e-10*mim_corner_2p0fF'
+.param c_vcr1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.param c_vcr2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+
+.param c_tnom=25
+.param c_tc1=1.46e-5
+.param c_tc2=-5.55e-8
+.param c_AREA='c_length*c_width'
+.param c_PERI='2*(c_length+c_width)'
+
+.param c_c0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temper +dtemp -c_tnom)+c_tc2*(temper+dtemp-c_tnom)*(temper+dtemp-c_tnom))'
+*
+c_cap 1 2 c='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+r_leak 1 2 r='1/(gleak*c_AREA)' tc1=c_tc1 tc2=c_tc2 dtemp=dtemp
+.ends cap_mim_2f0_m5m6_noshield
+
+.ENDL cap_mim_new
+* ----------------------------------------------------------------------------------------------------

--- a/models/ngspice/smbb000149.ngspice
+++ b/models/ngspice/smbb000149.ngspice
@@ -24,8 +24,8 @@
 *
 *      ModelName          Description
 *      ---------          -----------
-*      nmos_10p0_asym     BSIM4 based HV subcircuit model for 10V LDNMOS (*)
-*      pmos_10p0_asym     BSIM4 based HV subcircuit model for 10V LDPMOS (*)
+*      nfet_10v0_asym     BSIM4 based HV subcircuit model for 10V LDNMOS (*)
+*      pfet_10v0_asym     BSIM4 based HV subcircuit model for 10V LDPMOS (*)
 ************************************************************************************************
 *
 
@@ -36,35 +36,35 @@
 .param
 *************10V************
 
-+nmos_10p0_asym_dtox = 0
-+nmos_10p0_asym_dxl = 0
-+nmos_10p0_asym_dxw = 0 
-+nmos_10p0_asym_dvth0 = 0 
-+nmos_10p0_asym_drdsw = 1 
-+nmos_10p0_asym_drdrift = 1
-+nmos_10p0_asym_dvsat = 1 
-+nmos_10p0_asym_du0 = 1 
-+nmos_10p0_asym_dcgs = 1 
-+nmos_10p0_asym_dcgd = 1 
-+nmos_10p0_asym_dcjs = 1 
-+nmos_10p0_asym_dcjd = 1 
++nfet_10v0_asym_dtox = 0
++nfet_10v0_asym_dxl = 0
++nfet_10v0_asym_dxw = 0 
++nfet_10v0_asym_dvth0 = 0 
++nfet_10v0_asym_drdsw = 1 
++nfet_10v0_asym_drdrift = 1
++nfet_10v0_asym_dvsat = 1 
++nfet_10v0_asym_du0 = 1 
++nfet_10v0_asym_dcgs = 1 
++nfet_10v0_asym_dcgd = 1 
++nfet_10v0_asym_dcjs = 1 
++nfet_10v0_asym_dcjd = 1 
 
-+pmos_10p0_asym_dtox = 0
-+pmos_10p0_asym_dxl = 0
-+pmos_10p0_asym_dxw = 0
-+pmos_10p0_asym_dvth0 = 0
-+pmos_10p0_asym_drdsw = 1 
-+pmos_10p0_asym_drdrift = 1 
-+pmos_10p0_asym_dvsat = 1 
-+pmos_10p0_asym_du0 = 1
-+pmos_10p0_asym_dcgs = 1
-+pmos_10p0_asym_dcgd = 1 
-+pmos_10p0_asym_dcjs = 1
-+pmos_10p0_asym_dcjd = 1 
++pfet_10v0_asym_dtox = 0
++pfet_10v0_asym_dxl = 0
++pfet_10v0_asym_dxw = 0
++pfet_10v0_asym_dvth0 = 0
++pfet_10v0_asym_drdsw = 1 
++pfet_10v0_asym_drdrift = 1 
++pfet_10v0_asym_dvsat = 1 
++pfet_10v0_asym_du0 = 1
++pfet_10v0_asym_dcgs = 1
++pfet_10v0_asym_dcgd = 1 
++pfet_10v0_asym_dcjs = 1
++pfet_10v0_asym_dcjd = 1 
 
 
-.lib 'smbb000149.ngspice' nmos_10p0_asym_t
-.lib 'smbb000149.ngspice' pmos_10p0_asym_t
+.lib 'smbb000149.ngspice' nfet_10v0_asym_t
+.lib 'smbb000149.ngspice' pfet_10v0_asym_t
 .lib 'smbb000149.ngspice' noise_corner
 
 
@@ -73,35 +73,35 @@
 .LIB ss
 .param
 
-+nmos_10p0_asym_dtox = 8E-10 
-+nmos_10p0_asym_dxl = 6e-008 
-+nmos_10p0_asym_dxw = -3.46E-8
-+nmos_10p0_asym_dvth0 = 0.112 
-+nmos_10p0_asym_drdsw = 1.2 
-+nmos_10p0_asym_drdrift = 1.271 
-+nmos_10p0_asym_dvsat = 0.926 
-+nmos_10p0_asym_du0 = 0.95  
-+nmos_10p0_asym_dcgs = 1.1
-+nmos_10p0_asym_dcgd = 1.2 
-+nmos_10p0_asym_dcjs = 1.1
-+nmos_10p0_asym_dcjd = 1.2 
++nfet_10v0_asym_dtox = 8E-10 
++nfet_10v0_asym_dxl = 6e-008 
++nfet_10v0_asym_dxw = -3.46E-8
++nfet_10v0_asym_dvth0 = 0.112 
++nfet_10v0_asym_drdsw = 1.2 
++nfet_10v0_asym_drdrift = 1.271 
++nfet_10v0_asym_dvsat = 0.926 
++nfet_10v0_asym_du0 = 0.95  
++nfet_10v0_asym_dcgs = 1.1
++nfet_10v0_asym_dcgd = 1.2 
++nfet_10v0_asym_dcjs = 1.1
++nfet_10v0_asym_dcjd = 1.2 
 
 
-+pmos_10p0_asym_dtox = 8E-10
-+pmos_10p0_asym_dxl = 9.914e-008
-+pmos_10p0_asym_dxw = -1E-7
-+pmos_10p0_asym_dvth0 = -0.0936 
-+pmos_10p0_asym_drdsw = 1.11 
-+pmos_10p0_asym_drdrift = 1.144 
-+pmos_10p0_asym_dvsat = 0.91 
-+pmos_10p0_asym_du0 = 0.964 
-+pmos_10p0_asym_dcgs = 1.1
-+pmos_10p0_asym_dcgd = 1.2 
-+pmos_10p0_asym_dcjs = 1.1
-+pmos_10p0_asym_dcjd = 1.2 
++pfet_10v0_asym_dtox = 8E-10
++pfet_10v0_asym_dxl = 9.914e-008
++pfet_10v0_asym_dxw = -1E-7
++pfet_10v0_asym_dvth0 = -0.0936 
++pfet_10v0_asym_drdsw = 1.11 
++pfet_10v0_asym_drdrift = 1.144 
++pfet_10v0_asym_dvsat = 0.91 
++pfet_10v0_asym_du0 = 0.964 
++pfet_10v0_asym_dcgs = 1.1
++pfet_10v0_asym_dcgd = 1.2 
++pfet_10v0_asym_dcjs = 1.1
++pfet_10v0_asym_dcjd = 1.2 
 
-.lib 'smbb000149.ngspice' nmos_10p0_asym_t
-.lib 'smbb000149.ngspice' pmos_10p0_asym_t
+.lib 'smbb000149.ngspice' nfet_10v0_asym_t
+.lib 'smbb000149.ngspice' pfet_10v0_asym_t
 .lib 'smbb000149.ngspice' noise_corner
 
 
@@ -110,36 +110,36 @@
 .LIB ff
 .param
 
-+nmos_10p0_asym_dtox = -8E-10
-+nmos_10p0_asym_dxl = -6e-008 
-+nmos_10p0_asym_dxw = 3.46E-8
-+nmos_10p0_asym_dvth0 = -0.10388 
-+nmos_10p0_asym_drdsw = 0.868 
-+nmos_10p0_asym_drdrift = 0.8245 
-+nmos_10p0_asym_dvsat = 1.033 
-+nmos_10p0_asym_du0 = 1.04  
-+nmos_10p0_asym_dcgs = 0.9
-+nmos_10p0_asym_dcgd = 0.8 
-+nmos_10p0_asym_dcjs = 0.9
-+nmos_10p0_asym_dcjd = 0.8 
++nfet_10v0_asym_dtox = -8E-10
++nfet_10v0_asym_dxl = -6e-008 
++nfet_10v0_asym_dxw = 3.46E-8
++nfet_10v0_asym_dvth0 = -0.10388 
++nfet_10v0_asym_drdsw = 0.868 
++nfet_10v0_asym_drdrift = 0.8245 
++nfet_10v0_asym_dvsat = 1.033 
++nfet_10v0_asym_du0 = 1.04  
++nfet_10v0_asym_dcgs = 0.9
++nfet_10v0_asym_dcgd = 0.8 
++nfet_10v0_asym_dcjs = 0.9
++nfet_10v0_asym_dcjd = 0.8 
 
 
-+pmos_10p0_asym_dtox = -8E-10
-+pmos_10p0_asym_dxl = -6.804e-008 
-+pmos_10p0_asym_dxw = 8.46E-8
-+pmos_10p0_asym_dvth0 = 0.099  
-+pmos_10p0_asym_drdsw = 0.91 
-+pmos_10p0_asym_drdrift = 0.89 
-+pmos_10p0_asym_dvsat = 1.06 
-+pmos_10p0_asym_du0 = 1.03 
-+pmos_10p0_asym_dcgs = 0.9
-+pmos_10p0_asym_dcgd = 0.8 
-+pmos_10p0_asym_dcjs = 0.9
-+pmos_10p0_asym_dcjd = 0.8 
++pfet_10v0_asym_dtox = -8E-10
++pfet_10v0_asym_dxl = -6.804e-008 
++pfet_10v0_asym_dxw = 8.46E-8
++pfet_10v0_asym_dvth0 = 0.099  
++pfet_10v0_asym_drdsw = 0.91 
++pfet_10v0_asym_drdrift = 0.89 
++pfet_10v0_asym_dvsat = 1.06 
++pfet_10v0_asym_du0 = 1.03 
++pfet_10v0_asym_dcgs = 0.9
++pfet_10v0_asym_dcgd = 0.8 
++pfet_10v0_asym_dcjs = 0.9
++pfet_10v0_asym_dcjd = 0.8 
 
 
-.lib 'smbb000149.ngspice' nmos_10p0_asym_t
-.lib 'smbb000149.ngspice' pmos_10p0_asym_t
+.lib 'smbb000149.ngspice' nfet_10v0_asym_t
+.lib 'smbb000149.ngspice' pfet_10v0_asym_t
 .lib 'smbb000149.ngspice' noise_corner
 
 .ENDL
@@ -148,36 +148,36 @@
 .LIB sf
 .param
 
-+nmos_10p0_asym_dtox = 0
-+nmos_10p0_asym_dxl = 5.024e-008 
-+nmos_10p0_asym_dxw = 0
-+nmos_10p0_asym_dvth0 = 0.068 
-+nmos_10p0_asym_drdsw = 1.2 
-+nmos_10p0_asym_drdrift = 1.156 
-+nmos_10p0_asym_dvsat = 0.928 
-+nmos_10p0_asym_du0 = 0.97  
-+nmos_10p0_asym_dcgs = 1.07
-+nmos_10p0_asym_dcgd = 1.14
-+nmos_10p0_asym_dcjs = 1.07
-+nmos_10p0_asym_dcjd = 1.14
++nfet_10v0_asym_dtox = 0
++nfet_10v0_asym_dxl = 5.024e-008 
++nfet_10v0_asym_dxw = 0
++nfet_10v0_asym_dvth0 = 0.068 
++nfet_10v0_asym_drdsw = 1.2 
++nfet_10v0_asym_drdrift = 1.156 
++nfet_10v0_asym_dvsat = 0.928 
++nfet_10v0_asym_du0 = 0.97  
++nfet_10v0_asym_dcgs = 1.07
++nfet_10v0_asym_dcgd = 1.14
++nfet_10v0_asym_dcjs = 1.07
++nfet_10v0_asym_dcjd = 1.14
 
 
-+pmos_10p0_asym_dtox = 0
-+pmos_10p0_asym_dxl = -7.004e-008 
-+pmos_10p0_asym_dxw = 0
-+pmos_10p0_asym_dvth0 = 0.057672 
-+pmos_10p0_asym_drdsw = 0.91 
-+pmos_10p0_asym_drdrift = 0.92 
-+pmos_10p0_asym_dvsat = 1.012 
-+pmos_10p0_asym_du0 = 1.03 
-+pmos_10p0_asym_dcgs = 0.93
-+pmos_10p0_asym_dcgd = 0.86 
-+pmos_10p0_asym_dcjs = 0.93
-+pmos_10p0_asym_dcjd = 0.86 
++pfet_10v0_asym_dtox = 0
++pfet_10v0_asym_dxl = -7.004e-008 
++pfet_10v0_asym_dxw = 0
++pfet_10v0_asym_dvth0 = 0.057672 
++pfet_10v0_asym_drdsw = 0.91 
++pfet_10v0_asym_drdrift = 0.92 
++pfet_10v0_asym_dvsat = 1.012 
++pfet_10v0_asym_du0 = 1.03 
++pfet_10v0_asym_dcgs = 0.93
++pfet_10v0_asym_dcgd = 0.86 
++pfet_10v0_asym_dcjs = 0.93
++pfet_10v0_asym_dcjd = 0.86 
 
 
-.lib 'smbb000149.ngspice' nmos_10p0_asym_t
-.lib 'smbb000149.ngspice' pmos_10p0_asym_t
+.lib 'smbb000149.ngspice' nfet_10v0_asym_t
+.lib 'smbb000149.ngspice' pfet_10v0_asym_t
 .lib 'smbb000149.ngspice' noise_corner
 
 .ENDL
@@ -185,34 +185,34 @@
 .LIB fs
 .param
 
-+nmos_10p0_asym_dtox = 0
-+nmos_10p0_asym_dxl = -5.02e-008 
-+nmos_10p0_asym_dxw = 0
-+nmos_10p0_asym_dvth0 = -0.058169 
-+nmos_10p0_asym_drdsw = 0.868 
-+nmos_10p0_asym_drdrift = 0.89748 
-+nmos_10p0_asym_dvsat = 1.045 
-+nmos_10p0_asym_du0 = 1.034  
-+nmos_10p0_asym_dcgs = 0.93
-+nmos_10p0_asym_dcgd = 0.86 
-+nmos_10p0_asym_dcjs = 0.93
-+nmos_10p0_asym_dcjd = 0.86 
++nfet_10v0_asym_dtox = 0
++nfet_10v0_asym_dxl = -5.02e-008 
++nfet_10v0_asym_dxw = 0
++nfet_10v0_asym_dvth0 = -0.058169 
++nfet_10v0_asym_drdsw = 0.868 
++nfet_10v0_asym_drdrift = 0.89748 
++nfet_10v0_asym_dvsat = 1.045 
++nfet_10v0_asym_du0 = 1.034  
++nfet_10v0_asym_dcgs = 0.93
++nfet_10v0_asym_dcgd = 0.86 
++nfet_10v0_asym_dcjs = 0.93
++nfet_10v0_asym_dcjd = 0.86 
 
-+pmos_10p0_asym_dtox = 0
-+pmos_10p0_asym_dxl = 9.414e-008
-+pmos_10p0_asym_dxw = 0
-+pmos_10p0_asym_dvth0 = -0.056 
-+pmos_10p0_asym_drdsw = 1.11 
-+pmos_10p0_asym_drdrift = 1.06 
-+pmos_10p0_asym_dvsat = 0.989 
-+pmos_10p0_asym_du0 = 0.97 
-+pmos_10p0_asym_dcgs = 1.07
-+pmos_10p0_asym_dcgd = 1.14
-+pmos_10p0_asym_dcjs = 1.07
-+pmos_10p0_asym_dcjd = 1.14
++pfet_10v0_asym_dtox = 0
++pfet_10v0_asym_dxl = 9.414e-008
++pfet_10v0_asym_dxw = 0
++pfet_10v0_asym_dvth0 = -0.056 
++pfet_10v0_asym_drdsw = 1.11 
++pfet_10v0_asym_drdrift = 1.06 
++pfet_10v0_asym_dvsat = 0.989 
++pfet_10v0_asym_du0 = 0.97 
++pfet_10v0_asym_dcgs = 1.07
++pfet_10v0_asym_dcgd = 1.14
++pfet_10v0_asym_dcjs = 1.07
++pfet_10v0_asym_dcjd = 1.14
 
-.lib 'smbb000149.ngspice' nmos_10p0_asym_t
-.lib 'smbb000149.ngspice' pmos_10p0_asym_t
+.lib 'smbb000149.ngspice' nfet_10v0_asym_t
+.lib 'smbb000149.ngspice' pfet_10v0_asym_t
 .lib 'smbb000149.ngspice' noise_corner
 
 
@@ -256,52 +256,52 @@
 + mc_cgolP_10V=mc_cgolP_10V_2
 
 .param
-+nmos_10p0_asym_sig_vth='0.01675*(0.7*mc_sig_vth+0.7*mc_sig_vthN)*sw_stat_global*mc_skew'
-+nmos_10p0_asym_dtox='7.2e-11*(0.77*mc_toxe+0.63*mc_toxeN)*sw_stat_global*mc_skew'
-+nmos_10p0_asym_dxl='5.3e-9*(0.71*mc_xl+0.69*mc_xlN)*sw_stat_global*mc_skew'
-+nmos_10p0_asym_dxw='3.25e-8*(0.77*mc_xw+0.63*mc_xwN)*sw_stat_global*mc_skew'
-+nmos_10p0_asym_dvth0='nmos_10p0_asym_sig_vth'
-+nmos_10p0_asym_drdsw='(1 + 0.093*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
-+nmos_10p0_asym_drdrift='(1 + 0.037*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
-+nmos_10p0_asym_dvsat='(1 + 0.028*(0.77*mc_vsat_10v+0.63*mc_vsatN_10v)*sw_stat_global*mc_skew)'
-+nmos_10p0_asym_du0= '(1 + 0.0157*(0.7*mc_u0_10v+0.7*mc_u0n_10v)*sw_stat_global*mc_skew)'
-+nmos_10p0_asym_dcgs='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
-+nmos_10p0_asym_dcgd='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
-+nmos_10p0_asym_dcjs='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
-+nmos_10p0_asym_dcjd='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_sig_vth='0.01675*(0.7*mc_sig_vth+0.7*mc_sig_vthN)*sw_stat_global*mc_skew'
++nfet_10v0_asym_dtox='7.2e-11*(0.77*mc_toxe+0.63*mc_toxeN)*sw_stat_global*mc_skew'
++nfet_10v0_asym_dxl='5.3e-9*(0.71*mc_xl+0.69*mc_xlN)*sw_stat_global*mc_skew'
++nfet_10v0_asym_dxw='3.25e-8*(0.77*mc_xw+0.63*mc_xwN)*sw_stat_global*mc_skew'
++nfet_10v0_asym_dvth0='nfet_10v0_asym_sig_vth'
++nfet_10v0_asym_drdsw='(1 + 0.093*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_drdrift='(1 + 0.037*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_dvsat='(1 + 0.028*(0.77*mc_vsat_10v+0.63*mc_vsatN_10v)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_du0= '(1 + 0.0157*(0.7*mc_u0_10v+0.7*mc_u0n_10v)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_dcgs='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_dcgd='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_dcjs='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++nfet_10v0_asym_dcjd='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
 
 
 .param
-+pmos_10p0_asym_sig_dvth1='0.01692*(-0.7*mc_sig_vth+0.7*mc_sig_vthp)*sw_stat_global*mc_skew'
-+pmos_10p0_asym_dtox = '7.143e-11*(0.77*mc_toxe+0.63*mc_toxep)*sw_stat_global*mc_skew'
-+pmos_10p0_asym_dxl = '1.7e-8*(0.71*mc_xl+0.69*mc_xlp)*sw_stat_global*mc_skew'
-+pmos_10p0_asym_dxw = '7.4e-8*(0.77*mc_xw+0.63*mc_xwp)*sw_stat_global*mc_skew' 
-+pmos_10p0_asym_dvth0 = 'pmos_10p0_asym_sig_dvth1'
-+pmos_10p0_asym_drdsw = '(1 + 0.085*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)' 
-+pmos_10p0_asym_drdrift ='(1 + 0.032*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)'
-+pmos_10p0_asym_dvsat = '(1 + 0.032*(0.77*mc_vsat_10v+0.63*mc_vsatP_10V)*sw_stat_global*mc_skew)'
-+pmos_10p0_asym_du0 = '(1 + 0.0097*(0.7*mc_u0_10v+0.7*mc_u0P_10V)*sw_stat_global*mc_skew)'
-+pmos_10p0_asym_dcgs = '(1+ (12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'   
-+pmos_10p0_asym_dcgd = '(1+ (24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'  
-+pmos_10p0_asym_dcjs ='(1+(12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'   
-+pmos_10p0_asym_dcjd = '(1+(24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'   
++pfet_10v0_asym_sig_dvth1='0.01692*(-0.7*mc_sig_vth+0.7*mc_sig_vthp)*sw_stat_global*mc_skew'
++pfet_10v0_asym_dtox = '7.143e-11*(0.77*mc_toxe+0.63*mc_toxep)*sw_stat_global*mc_skew'
++pfet_10v0_asym_dxl = '1.7e-8*(0.71*mc_xl+0.69*mc_xlp)*sw_stat_global*mc_skew'
++pfet_10v0_asym_dxw = '7.4e-8*(0.77*mc_xw+0.63*mc_xwp)*sw_stat_global*mc_skew' 
++pfet_10v0_asym_dvth0 = 'pfet_10v0_asym_sig_dvth1'
++pfet_10v0_asym_drdsw = '(1 + 0.085*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)' 
++pfet_10v0_asym_drdrift ='(1 + 0.032*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)'
++pfet_10v0_asym_dvsat = '(1 + 0.032*(0.77*mc_vsat_10v+0.63*mc_vsatP_10V)*sw_stat_global*mc_skew)'
++pfet_10v0_asym_du0 = '(1 + 0.0097*(0.7*mc_u0_10v+0.7*mc_u0P_10V)*sw_stat_global*mc_skew)'
++pfet_10v0_asym_dcgs = '(1+ (12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'   
++pfet_10v0_asym_dcgd = '(1+ (24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'  
++pfet_10v0_asym_dcjs ='(1+(12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'   
++pfet_10v0_asym_dcjd = '(1+(24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'   
 
 
-.lib 'smbb000149.ngspice' nmos_10p0_asym_t
-.lib 'smbb000149.ngspice' pmos_10p0_asym_t
+.lib 'smbb000149.ngspice' nfet_10v0_asym_t
+.lib 'smbb000149.ngspice' pfet_10v0_asym_t
 .lib 'smbb000149.ngspice' noise_corner
 .ENDL
 
 *
 .LIB noise_corner
  .param
- +nmos_10p0_asym_noia='(fnoicor==0)*1.1021E42 + (fnoicor==1)*2.5852e42' 
- +nmos_10p0_asym_noib='(fnoicor==0)*2.8476E24 + (fnoicor==1)*6.5096e+024' 
- +nmos_10p0_asym_noic='(fnoicor==0)*8.75 + (fnoicor==1)*8.75'
+ +nfet_10v0_asym_noia='(fnoicor==0)*1.1021E42 + (fnoicor==1)*2.5852e42' 
+ +nfet_10v0_asym_noib='(fnoicor==0)*2.8476E24 + (fnoicor==1)*6.5096e+024' 
+ +nfet_10v0_asym_noic='(fnoicor==0)*8.75 + (fnoicor==1)*8.75'
 
- +pmos_10p0_asym_noia='(fnoicor==0)*2.9073e+041 + (fnoicor==1)*1.7073e+042' 
- +pmos_10p0_asym_noib='(fnoicor==0)*8.0736e+025 + (fnoicor==1)*2.4523e+026' 
- +pmos_10p0_asym_noic='(fnoicor==0)*12780 + (fnoicor==1)*12780'
+ +pfet_10v0_asym_noia='(fnoicor==0)*2.9073e+041 + (fnoicor==1)*1.7073e+042' 
+ +pfet_10v0_asym_noib='(fnoicor==0)*8.0736e+025 + (fnoicor==1)*2.4523e+026' 
+ +pfet_10v0_asym_noic='(fnoicor==0)*12780 + (fnoicor==1)*12780'
 
 .ENDL
 *
@@ -311,9 +311,9 @@
 ***************************************************************************************************
 *
 
-.lib nmos_10p0_asym_t  
+.lib nfet_10v0_asym_t  
 
-.subckt nmos_10p0_asym d g s b w = 25E-6       l = 0.6E-6       ad = 'w*1.48e-6' pd = '2*(1.48e-6+w)' as = 'w*0.48e-6' ps = '(w+0.48e-6)*2' nrd = 0        
+.subckt nfet_10v0_asym d g s b w = 25E-6       l = 0.6E-6       ad = 'w*1.48e-6' pd = '2*(1.48e-6+w)' as = 'w*0.48e-6' ps = '(w+0.48e-6)*2' nrd = 0        
 +nrs = 0        nf = 1         dtemp = 0      
 +sa = 0         sb = 0         sd = 0         
 +par = 1        
@@ -333,15 +333,15 @@
 +cgs_vth1 = 0.20635            
 .param
 +cgds_fixed = '3.9*8.854e-12/toxep' 
-rdrift d d2 '(rdrift1*nmos_10p0_asym_drdrift)*1.2e-6/(w/nf-wa)' tc1=trx1 tc2=trx2 m=nf
-rd2 d2 d1 'max(1e-2, (rd*nmos_10p0_asym_drdsw*(1+trth1*(temper+dtemp-25)+trth2*(temper+dtemp-25)*(temper+dtemp-25)))/(w/nf-wb)*(tanh(ra*(v(d,s)-rb*(l-lb)/(0.6e-6-lb)))))' m=nf
-m0 d1 g s b nmos_10p0_asym_core w=w l=l as=as ad=ad ps=ps pd=pd nf=nf nrd=nrd nrs=nrs sa=sa sb=sb sd=sd
-c1_gd g d c='nmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1)) -nmos_10p0_asym_dvth0))))'
-c1_gd2 g d1 c='nmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1))  -nmos_10p0_asym_dvth0 ) )) )'
-c2_gs g s c='nmos_10p0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(-v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(v(d1,s)-vthd,0),polars_min)))))'
-c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + nmos_10p0_asym_dvth0)), cgb_power))) ) *w '
+rdrift d d2 '(rdrift1*nfet_10v0_asym_drdrift)*1.2e-6/(w/nf-wa)' tc1=trx1 tc2=trx2 m=nf
+rd2 d2 d1 'max(1e-2, (rd*nfet_10v0_asym_drdsw*(1+trth1*(temper+dtemp-25)+trth2*(temper+dtemp-25)*(temper+dtemp-25)))/(w/nf-wb)*(tanh(ra*(v(d,s)-rb*(l-lb)/(0.6e-6-lb)))))' m=nf
+m0 d1 g s b nfet_10v0_asym_core w=w l=l as=as ad=ad ps=ps pd=pd nf=nf nrd=nrd nrs=nrs sa=sa sb=sb sd=sd
+c1_gd g d c='nfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1)) -nfet_10v0_asym_dvth0))))'
+c1_gd2 g d1 c='nfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1))  -nfet_10v0_asym_dvth0 ) )) )'
+c2_gs g s c='nfet_10v0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(-v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(v(d1,s)-vthd,0),polars_min)))))'
+c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + nfet_10v0_asym_dvth0)), cgb_power))) ) *w '
 
-.model nmos_10p0_asym_core.1 nmos
+.model nfet_10v0_asym_core.1 nmos
 ***** Flag Parameter ***
 +level = 54                    version = 4.6                 binunit = 1                   
 +paramchk = 1                  mobmod = 0                    capmod = 2                    
@@ -353,7 +353,7 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 +lmin = 6E-7                   lmax = 20.01E-6               wmin = 4E-6                   
 +wmax = 50.01E-6              
 ***** Process Parameter ***
-+epsrox = 3.9                  toxe = '1.398E-8+nmos_10p0_asym_dtox'               xj = 1.5E-7                   
++epsrox = 3.9                  toxe = '1.398E-8+nfet_10v0_asym_dtox'               xj = 1.5E-7                   
 +ndep = 1.7E17                 ngate = 2.9861E21             nsd = 1E20                    
 +rsh = 7                       phin = 0                      
 ***** dW and dL Parameter ***
@@ -361,10 +361,10 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 +ww = 0                        wwn = 1                       wwl = 0                       
 +lint = 0                      ll = 0                        lln = 1                       
 +lw = 0                        lwn = 1                       lwl = 0                       
-+dwg = -2.9807E-8              dwb = -3.3647E-8              xl = '0+nmos_10p0_asym_dxl'                        
-+xw = '0+nmos_10p0_asym_dxw'                        
++dwg = -2.9807E-8              dwb = -3.3647E-8              xl = '0+nfet_10v0_asym_dxl'                        
++xw = '0+nfet_10v0_asym_dxw'                        
 ***** Vth Related  Parameter ***
-+vth0 = '0.653 +nmos_10p0_asym_dvth0'                 lvth0 = 0                     wvth0 = 0                     
++vth0 = '0.653 +nfet_10v0_asym_dvth0'                 lvth0 = 0                     wvth0 = 0                     
 +pvth0 = 0.19879               vfb = -0.55                   k1 = 0.9621                   
 +lk1 = 0                       k2 = -7.2357E-3               lk2 = 0                       
 +k3 = 13.237                   wk3 = 0                       k3b = 0.25485                 
@@ -373,16 +373,16 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 +dvt1 = 0.021131               dvt2 = -0.046683              dvt0w = 3.4488                
 +dvt1w = 9.5865E4              dvt2w = 0.034426              
 ***** Mobility Related Parameter ***
-+u0 = '0.0486*nmos_10p0_asym_du0'                   lu0 = '5.2003E-3*nmos_10p0_asym_du0'               wu0 = '-0.020672*nmos_10p0_asym_du0'               
-+pu0 = '3.9064E-3*nmos_10p0_asym_du0'               ua = -1.05E-10                lua = 4.2194E-10              
++u0 = '0.0486*nfet_10v0_asym_du0'                   lu0 = '5.2003E-3*nfet_10v0_asym_du0'               wu0 = '-0.020672*nfet_10v0_asym_du0'               
++pu0 = '3.9064E-3*nfet_10v0_asym_du0'               ua = -1.05E-10                lua = 4.2194E-10              
 +pua = 0                       ub = 3.0678E-18               lub = -1.9302E-18             
 +pub = -6.8E-19                uc = 1.0312E-10               luc = -4.7702E-11             
-+puc = -6.8588E-11             vsat = '7.9784E4*nmos_10p0_asym_dvsat'               lvsat = '9844*nmos_10p0_asym_dvsat'                
++puc = -6.8588E-11             vsat = '7.9784E4*nfet_10v0_asym_dvsat'               lvsat = '9844*nfet_10v0_asym_dvsat'                
 +wvsat = 0                     pvsat = -3.168E3              a0 = 1.0212                   
 +la0 = -0.55504                ags = 0.13804                 lags = 0                      
 +wags = -0.012                 b0 = 6.48E-6                  b1 = 5.9519E-5                
 +keta = -0.01362               lketa = -3.3807E-3            a1 = -0.065307                
-+a2 = 0.94                     rdsw = '200*nmos_10p0_asym_drdsw'                    prdsw = 0                     
++a2 = 0.94                     rdsw = '200*nfet_10v0_asym_drdsw'                    prdsw = 0                     
 +rdswmin = 500                 prwb = 0.81                   pprwb = 0                     
 +prwg = 0.037838               pprwg = 0                     wr = 1                        
 ***** Subthreshold Related Parameter ***
@@ -400,7 +400,7 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 +agidl = 5.7877E-16            bgidl = 1.171E9               cgidl = 0.228                 
 +egidl = 0.0968                
 ***** Flicker Noise Model Parameter ***
-+noia = 'nmos_10p0_asym_noia'               noib = 'nmos_10p0_asym_noib'            noic = 'nmos_10p0_asym_noic'               
++noia = 'nfet_10v0_asym_noia'               noib = 'nfet_10v0_asym_noib'            noic = 'nfet_10v0_asym_noic'               
 +em = 4.1E7                    ef = 1.0914                     
 ***** Capacitance Parameter ***
 +xpart = 1                     cgso = 0                      cgdo = 0                      
@@ -413,10 +413,10 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 +bvd = 14.5                      jss = 6.88E-7                 jsd = 1.6119E-6               
 +jsws = 4.88E-13               jswd = 4.824E-12              jswgs = 4.88E-13              
 +jswgd = 4.824E-12             jtsd = 1.4513E-4              xtsd = 0.63818                
-+vtsd = 2.16                   cjs = '9.5E-4*nmos_10p0_asym_dcjs'                  cjd = '1.4914E-4*nmos_10p0_asym_dcjd'               
++vtsd = 2.16                   cjs = '9.5E-4*nfet_10v0_asym_dcjs'                  cjd = '1.4914E-4*nfet_10v0_asym_dcjd'               
 +mjs = 0.296                   mjd = 0.30525                 mjsws = 0.01                  
-+mjswd = 0.21757               cjsws = '1.33E-10*nmos_10p0_asym_dcjs'              cjswd = '5.8719E-10*nmos_10p0_asym_dcjd'            
-+cjswgs = '1.33E-10*nmos_10p0_asym_dcjs'             cjswgd = '5.8719E-10*nmos_10p0_asym_dcjd'           mjswgs = 0.01                 
++mjswd = 0.21757               cjsws = '1.33E-10*nfet_10v0_asym_dcjs'              cjswd = '5.8719E-10*nfet_10v0_asym_dcjd'            
++cjswgs = '1.33E-10*nfet_10v0_asym_dcjs'             cjswgd = '5.8719E-10*nfet_10v0_asym_dcjd'           mjswgs = 0.01                 
 +mjswgd = 0.21757              pbs = 0.606                   pbd = 0.43905                 
 +pbsws = 0.48                  pbswd = 0.48991               pbswgs = 0.48                 
 +pbswgd = 0.48991              
@@ -432,9 +432,9 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 +xtis = 3                      xtid = 3                      tpb = 2.11E-3                 
 +tpbsw = 1.9E-3                tpbswg = 1.9E-3               tcj = 1.65E-3                 
 +tcjsw = 1.61E-3               tcjswg = 1.61E-3              
-.ends nmos_10p0_asym
+.ends nfet_10v0_asym
 
-.endl nmos_10p0_asym_t 
+.endl nfet_10v0_asym_t 
 
 *
 ***************************************************************************************************
@@ -442,9 +442,9 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 ***************************************************************************************************
 *
 
-.lib pmos_10p0_asym_t  
+.lib pfet_10v0_asym_t  
 
-.subckt pmos_10p0_asym d g s b w = 2.5E-5     l = 6E-7       dtemp = 0      nf = 1         ad = '(w*1.78e-6)' pd = '2*(w+1.78e-6)' as = 'w*0.48e-6' 
+.subckt pfet_10v0_asym d g s b w = 2.5E-5     l = 6E-7       dtemp = 0      nf = 1         ad = '(w*1.78e-6)' pd = '2*(w+1.78e-6)' as = 'w*0.48e-6' 
 +ps = '(w+0.48e-6)*2' nrd = 0        nrs = 0        
 +sa = 0         sb = 0         sd = 0         
 +par = 1        
@@ -463,15 +463,15 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + n
 +cgdv_d2 = -1.2197             cgdl_d = 1.6046E-11           cgs_vth1 = 0.13041            
 .param
 +cgds_fixed = '3.9*8.854e-12/toxep' 
-rd1 d d2 '(rdrift*pmos_10p0_asym_drdrift)/(w/nf-wa)' tc1=trx1 tc2=trx2 m=nf
-rd2 d2 d1 'max(0.1, (rd*pmos_10p0_asym_drdsw*(1+trd1*(temper+dtemp-25))/(w/nf-wb)*(tanh(ra*(v(s,d)-rb*(l-lb)/(0.6e-6-lb))))))' m=nf
-m0 d1 g s b pmos_10p0_asym_core w=w l=l dtemp=0 ad=ad pd=pd as=as ps=ps nf=nf nrd=nrd nrs=nrs sa=sa sb=sb sd=sd
-c1_gd g d c='pmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(-v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pmos_10p0_asym_dvth0))))'
-c1_gd2 g d1 c='pmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pmos_10p0_asym_dvth0   ) )) )'
-c2_gs g s c='pmos_10p0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(-v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(-v(d1,s)-vthd,0),polars_min)))))'
-c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + pmos_10p0_asym_dvth0)), cgb_power))) ) *w '
+rd1 d d2 '(rdrift*pfet_10v0_asym_drdrift)/(w/nf-wa)' tc1=trx1 tc2=trx2 m=nf
+rd2 d2 d1 'max(0.1, (rd*pfet_10v0_asym_drdsw*(1+trd1*(temper+dtemp-25))/(w/nf-wb)*(tanh(ra*(v(s,d)-rb*(l-lb)/(0.6e-6-lb))))))' m=nf
+m0 d1 g s b pfet_10v0_asym_core w=w l=l dtemp=0 ad=ad pd=pd as=as ps=ps nf=nf nrd=nrd nrs=nrs sa=sa sb=sb sd=sd
+c1_gd g d c='pfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(-v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pfet_10v0_asym_dvth0))))'
+c1_gd2 g d1 c='pfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pfet_10v0_asym_dvth0   ) )) )'
+c2_gs g s c='pfet_10v0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(-v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(-v(d1,s)-vthd,0),polars_min)))))'
+c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + pfet_10v0_asym_dvth0)), cgb_power))) ) *w '
 
-.model pmos_10p0_asym_core.1 pmos
+.model pfet_10v0_asym_core.1 pmos
 ***** Flag Parameter ***
 +level = 54                    version = 4.6                 binunit = 2                   
 +paramchk = 1                  mobmod = 0                    capmod = 2                    
@@ -481,9 +481,9 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + 
 +tempmod = 0                   permod = 1                    geomod = 0                    
 ***** Geometry Range Parameter ***
 +lmin = 6E-7                   lmax = 20.01E-6                wmin = 4e-6                   
-+wmax = 50.01e-6                  xl = ' 0 + pmos_10p0_asym_dxl' xw = '0+ pmos_10p0_asym_dxw'
++wmax = 50.01e-6                  xl = ' 0 + pfet_10v0_asym_dxl' xw = '0+ pfet_10v0_asym_dxw'
 ***** Process Parameter ***
-+epsrox = 3.9                  toxe = '1.568E-8+pmos_10p0_asym_dtox'               xj = 1.5E-7                   
++epsrox = 3.9                  toxe = '1.568E-8+pfet_10v0_asym_dtox'               xj = 1.5E-7                   
 +ndep = 1.7E17                 ngate = 1E20                  nsd = 1E20                    
 +rsh = 5.6                     rshg = 0.4                    phin = 0.061992               
 ***** dW and dL Parameter ***
@@ -491,7 +491,7 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + 
 +lint = 0                      ll = 0                        lwl = 0                       
 +dwg = 1.0544E-8               dwb = 0                       
 ***** Vth Related  Parameter ***
-+vth0 = '-0.888+pmos_10p0_asym_dvth0'                wvth0 = 0                     pvth0 = 1.44E-14              
++vth0 = '-0.888+pfet_10v0_asym_dvth0'                wvth0 = 0                     pvth0 = 1.44E-14              
 +vfb = -1                      k1 = 1.09                     k2 = -0.014623                
 +wk2 = 0                       pk2 = -9.04E-14               k3 = 5.4746                   
 +k3b = 3.8727                  w0 = 3.24E-6                  lpe0 = 2.814E-7               
@@ -502,16 +502,16 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + 
 +pdvt1 = 0                     dvt2 = -0.038473              dvt0w = 0                     
 +dvt1w = 2.7518E4              dvt2w = -0.032                
 ***** Mobility Related Parameter ***
-+u0 = '0.013723*pmos_10p0_asym_du0'                 lu0 = '2.7385E-9*pmos_10p0_asym_du0'               wu0 = '-7E-10*pmos_10p0_asym_du0'                  
-+pu0 = '-2E-15*pmos_10p0_asym_du0'                  ua = 1.26E-9                  lua = 1.2893E-16              
++u0 = '0.013723*pfet_10v0_asym_du0'                 lu0 = '2.7385E-9*pfet_10v0_asym_du0'               wu0 = '-7E-10*pfet_10v0_asym_du0'                  
++pu0 = '-2E-15*pfet_10v0_asym_du0'                  ua = 1.26E-9                  lua = 1.2893E-16              
 +pua = 6.315E-22               ub = 7.2608E-19               lub = 0                       
 +uc = -4.5217E-11              luc = 5.88E-17                eu = 1.67                     
-+vsat = '71505*pmos_10p0_asym_dvsat'                  wvsat = 0                     pvsat = 0                     
++vsat = '71505*pfet_10v0_asym_dvsat'                  wvsat = 0                     pvsat = 0                     
 +a0 = 1.1348                   la0 = -3.8459E-7              ags = 0.0834                  
 +lags = 0                      wags = 6.5664E-9              pags = 6.4229E-13             
 +b0 = 0                        b1 = 0                        keta = -1.504E-3              
 +lketa = -2.0415E-8            wketa = 2.68e-008             pketa = -7.5094e-014            
-+a1 = -0.07052                 a2 = 1                        rdsw = '200*pmos_10p0_asym_drdsw'                    
++a1 = -0.07052                 a2 = 1                        rdsw = '200*pfet_10v0_asym_drdsw'                    
 +rdswmin = 0                   rdw = 100                     rdwmin = 0                    
 +rsw = 100                     rswmin = 0                    prwb = 1.24                   
 +prwg = 1                      wr = 1                        
@@ -540,7 +540,7 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + 
 +agidl = 3.7498E-17            bgidl = 1.196E8               cgidl = 0.5                   
 +egidl = 0.8                   
 ***** Flicker Noise Model Parameter ***
-+noia = 'pmos_10p0_asym_noia'             noib = 'pmos_10p0_asym_noib'              noic = 'pmos_10p0_asym_noic'                
++noia = 'pfet_10v0_asym_noia'             noib = 'pfet_10v0_asym_noib'              noic = 'pfet_10v0_asym_noic'                
 +em = 4.1E7                    ef = 1.1237                   
 ***** Capacitance Parameter ***
 +cgso = 0                      cgdo = 0                      cgbo = 0                      
@@ -554,10 +554,10 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + 
 +bvd = 14.5                    jss = 2.0867E-7               jsd = 5.2139E-7               
 +jsws = 1.6088E-13             jswd = 1.5E-13                jswgs = 1.6088E-13            
 +jswgd = 1.5E-13               jtsd = 1.0891E-6              xtsd = 0.92538                
-+vtsd = 2.44                   cjs = '9.12E-4*pmos_10p0_asym_dcjs'                 cjd = '3.2124E-4*pmos_10p0_asym_dcjd'               
++vtsd = 2.44                   cjs = '9.12E-4*pfet_10v0_asym_dcjs'                 cjd = '3.2124E-4*pfet_10v0_asym_dcjd'               
 +mjs = 0.32713                 mjd = 0.31113                 mjsws = 0.056777              
-+mjswd = 0.39816               cjsws = '1.4649E-10*pmos_10p0_asym_dcjs'            cjswd = '5.4659E-10*pmos_10p0_asym_dcjd'            
-+cjswgs = '1.4649E-10*pmos_10p0_asym_dcjs'           cjswgd = '5.4659E-10*pmos_10p0_asym_dcjd'           mjswgs = 0.056777             
++mjswd = 0.39816               cjsws = '1.4649E-10*pfet_10v0_asym_dcjs'            cjswd = '5.4659E-10*pfet_10v0_asym_dcjd'            
++cjswgs = '1.4649E-10*pfet_10v0_asym_dcjs'           cjswgd = '5.4659E-10*pfet_10v0_asym_dcjd'           mjswgs = 0.056777             
 +mjswgd = 0.39816              pbs = 0.76836                 pbd = 0.63391                 
 +pbsws = 0.5                   pbswd = 0.77752               pbswgs = 0.5                  
 +pbswgd = 0.77752              
@@ -568,11 +568,11 @@ c3_gb g b '(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + 
 +pkt2 = -1.1E-13               ua1 = 5E-10                   lua1 = 0                      
 +ub1 = -2.2324E-18             lub1 = -2.0019E-25            uc1 = -3.0912E-11             
 +luc1 = 0                      at = 3.96E3                   prt = 0                       
-.ends pmos_10p0_asym
+.ends pfet_10v0_asym
 
 
 
-.endl pmos_10p0_asym_t 
+.endl pfet_10v0_asym_t 
 
 
 ************************end of file*************************

--- a/models/ngspice/testing/regression/mimcap_c/models_regression.py
+++ b/models/ngspice/testing/regression/mimcap_c/models_regression.py
@@ -123,7 +123,11 @@ def main():
 
     # mim
     corners = ["ss" , "typical","ff"]        
-    devices = ["mim_1p5fF" , "mim_1p0fF" , "mim_2p0fF"]
+    devices = ["cap_mim_1f5_m2m3_noshield" , "cap_mim_1f0_m2m3_noshield" , "cap_mim_2f0_m2m3_noshield" ,\
+               "cap_mim_1f5_m3m4_noshield" , "cap_mim_1f0_m3m4_noshield" , "cap_mim_2f0_m3m4_noshield" ,\
+               "cap_mim_1f5_m4m5_noshield" , "cap_mim_1f0_m4m5_noshield" , "cap_mim_2f0_m4m5_noshield" ,\
+               "cap_mim_1f5_m5m6_noshield" , "cap_mim_1f0_m5m6_noshield" , "cap_mim_2f0_m5m6_noshield" ]
+
     measure = ["cv","corners", "CV (fF)"]
     start = 0
     for corner in corners: 

--- a/models/xyce/sm141064.xyce
+++ b/models/xyce/sm141064.xyce
@@ -37,36 +37,36 @@
 *
 *      ModelName          Description
 *      ---------          -----------
-*      nmos_3p3           Subcircuit model for 3.3V NMOS
-*      pmos_3p3           Subcircuit model for 3.3V PMOS
-*      nmos_6p0           Subcircuit model for 6.0V NMOS
-*      pmos_6p0           Subcircuit model for 6.0V PMOS
-*      nmos_3p3_sab       Subcircuit model for 3.3V NMOS with Drain side SAB
-*      pmos_3p3_sab       Subcircuit model for 3.3V PMOS with Drain side SAB
-*      nmos_6p0_sab       Subcircuit model for 6.0V NMOS with Drain side SAB
-*      pmos_6p0_sab       Subcircuit model for 6.0V PMOS with Drain side SAB
-*      nmos_6p0_nat       Subcircuit model for 6.0V native NMOS
+*      nfet_03v3           Subcircuit model for 3.3V NMOS
+*      pfet_03v3           Subcircuit model for 3.3V PMOS
+*      nfet_06v0           Subcircuit model for 6.0V NMOS
+*      pfet_06v0           Subcircuit model for 6.0V PMOS
+*      nfet_03v3_dss       Subcircuit model for 3.3V NMOS with Drain side SAB
+*      pfet_03v3_dss       Subcircuit model for 3.3V PMOS with Drain side SAB
+*      nfet_06v0_dss       Subcircuit model for 6.0V NMOS with Drain side SAB
+*      pfet_06v0_dss       Subcircuit model for 6.0V PMOS with Drain side SAB
+*      nfet_06v0_nvt       Subcircuit model for 6.0V native NMOS
 *
-*      np_3p3             Model for 3.3V N+/Psub diode
-*      pn_3p3             Model for 3.3V P+/Nwell diode
-*      np_6p0             Model for 6.0V N+/Psub diode
-*      pn_6p0             Model for 6.0V P+/Nwell diode
-*      nwp_3p3            Model for 3.3V Nwell/Psub diode
-*      nwp_6p0            Model for 6.0V Nwell/Psub diode
-*      dnwpw              Model for PWELL/DNWELL diode
-*      dnwps	          Model for DNWELL/Psub diode
+*      diode_nd2ps_03v3             Model for 3.3V N+/Psub diode
+*      diode_pd2nw_03v3             Model for 3.3V P+/Nwell diode
+*      diode_nd2ps_06v0             Model for 6.0V N+/Psub diode
+*      diode_pd2nw_06v0             Model for 6.0V P+/Nwell diode
+*      diode_nw2ps_03v3            Model for 3.3V Nwell/Psub diode
+*      diode_nw2ps_06v0            Model for 6.0V Nwell/Psub diode
+*      diode_pw2dw              Model for PWELL/DNWELL diode
+*      diode_dw2ps	          Model for DNWELL/Psub diode
 *      sc_diode           Model for Schottky Diode
 *
-*      vpnp_0p42x10       Subcircuit GP model for VPNP with emitter size of 10umx0.42um
-*      vpnp_0p42x5        Subcircuit GP model for VPNP with emitter size of 5umx0.42um
-*      vpnp_10x10         Subcircuit GP model for VPNP with emitter size of 10umx10um
-*      vpnp_5x5           Subcircuit GP model for VPNP with emitter size of 5umx5um
-*      vnpn_10x10         Subcircuit GP model for VNPN with emitter size of 10umx10um(four terminal)
-*      vnpn_5x5        	  Subcircuit GP model for VNPN with emitter size of 5umx5um(four terminal)
-*      vnpn_0p54x16       Subcircuit GP model for VNPN with emitter size of 0.54umx16um(four terminal)
-*      vnpn_0p54x8        Subcircuit GP model for VNPN with emitter size of 0.54umx8um(four terminal)
-*      vnpn_0p54x4        Subcircuit GP model for VNPN with emitter size of 0.54umx4um(four terminal)
-*      vnpn_0p54x2        Subcircuit GP model for VNPN with emitter size of 0.54umx2um(four terminal)
+*      pnp_10p00x00p42       Subcircuit GP model for VPNP with emitter size of 10umx0.42um
+*      pnp_05p00x00p42        Subcircuit GP model for VPNP with emitter size of 5umx0.42um
+*      pnp_10p00x10p00         Subcircuit GP model for VPNP with emitter size of 10umx10um
+*      pnp_05p00x05p00           Subcircuit GP model for VPNP with emitter size of 5umx5um
+*      npn_10p00x10p00         Subcircuit GP model for VNPN with emitter size of 10umx10um(four terminal)
+*      npn_05p00x05p00        	  Subcircuit GP model for VNPN with emitter size of 5umx5um(four terminal)
+*      npn_00p54x16p00       Subcircuit GP model for VNPN with emitter size of 0.54umx16um(four terminal)
+*      npn_00p54x08p00        Subcircuit GP model for VNPN with emitter size of 0.54umx8um(four terminal)
+*      npn_00p54x04p00        Subcircuit GP model for VNPN with emitter size of 0.54umx4um(four terminal)
+*      npn_00p54x02p00        Subcircuit GP model for VNPN with emitter size of 0.54umx2um(four terminal)
 *
 *      nplus_u            Subcircuit Model for 3-terminal unsalicided n+ diffusion resistor
 *      pplus_u            Subcircuit Model for 3-terminal unsalicided P+ diffusion resistor
@@ -90,190 +90,190 @@
 *      tm11k              Subcircuit Model for 2-terminal top metal 11k resistor
 *      tm30k              Subcircuit Model for 2-terminal top metal 30k resistor
 *
-*      mim_1p5fF          Subcircuit Model for 1.5fF/um2 MIM (*)-usable for Volt <=6V across capacitor
-*      mim_1p0fF          Subcircuit Model for 1.0fF/um2 MIM (*)-usable for Volt <=20V across capacitor
-*      mim_2p0fF          Subcircuit Model for 2fF/um2 MIM      -usable for Volt <=6V across capacitor
+*      cap_mim_1f5fF          Subcircuit Model for 1.5fF/um2 MIM (*)-usable for Volt <=6V across capacitor
+*      cap_mim_1f0fF          Subcircuit Model for 1.0fF/um2 MIM (*)-usable for Volt <=20V across capacitor
+*      cap_mim_2f0fF          Subcircuit Model for 2fF/um2 MIM      -usable for Volt <=6V across capacitor
 *
-*      nmoscap_3p3        Subcircuit Model for 3.3v inversion-mode  NMOS capacitor
-*      pmoscap_3p3	 	  Subcircuit Model for 3.3v inversion-mode  PMOS capacitor
-*      nmoscap_6p0        Subcircuit Model for 6.0V inversion-mode  NMOS capacitor
-*      pmoscap_6p0	  	  Subcircuit Model for 6.0V inversion-mode  PMOS capacitor
-*      nmoscap_3p3_b      Subcircuit Model for 3.3v NMOS in Nwell capacitor
-*      pmoscap_3p3_b	  Subcircuit Model for 3.3v PMOS in Pwell capacitor
-*      nmoscap_6p0_b      Subcircuit Model for 6.0V NMOS in Nwell capacitor
-*      pmoscap_6p0_b	  Subcircuit Model for 6.0V PMOS in Pwell capacitor
+*      cap_nmos_03v3        Subcircuit Model for 3.3v inversion-mode  NMOS capacitor
+*      cap_pmos_03v3	 	  Subcircuit Model for 3.3v inversion-mode  PMOS capacitor
+*      cap_nmos_06v0        Subcircuit Model for 6.0V inversion-mode  NMOS capacitor
+*      cap_pmos_06v0	  	  Subcircuit Model for 6.0V inversion-mode  PMOS capacitor
+*      cap_nmos_03v3_b      Subcircuit Model for 3.3v NMOS in Nwell capacitor
+*      cap_pmos_03v3_b	  Subcircuit Model for 3.3v PMOS in Pwell capacitor
+*      cap_nmos_06v0_b      Subcircuit Model for 6.0V NMOS in Nwell capacitor
+*      cap_pmos_06v0_b	  Subcircuit Model for 6.0V PMOS in Pwell capacitor
 *
 *      efuse    	      Subcircuit model for 6V/(5V) efuse
 ************************************************************************************************
 *
 .LIB typical
-.LIB sm141064.xyce nmos_3p3_t
-.LIB sm141064.xyce pmos_3p3_t
+.LIB sm141064.xyce nfet_03v3_t
+.LIB sm141064.xyce pfet_03v3_t
 *
 .PARAM RSH_NPLUS_U_M=60
 .PARAM RSH_PPLUS_U_M=185
-.PARAM NMOS_6P0_VSAT=1
-.PARAM NMOS_6P0_VTH0=0
-.PARAM NMOS_6P0_XL=0
-.PARAM NMOS_6P0_XW=0
-.PARAM NMOS_6P0_TOX=0
-.PARAM NMOS_6P0_CGSO=1
-.PARAM NMOS_6P0_CGDO=1
-.PARAM NMOS_6P0_NAT_U0='0.070102'
-.PARAM NMOS_6P0_NAT_VTH0='-0.039'
-.PARAM NMOS_6P0_NAT_XL='0'
-.PARAM NMOS_6P0_NAT_XW='0'
-.PARAM NMOS_6P0_NAT_TOX='1.52e-008'
-.PARAM NMOS_6P0_NAT_CGSO='1e-010'
-.PARAM NMOS_6P0_NAT_CGDO='1e-010'
-.PARAM PMOS_6P0_DVTH0=0
-.PARAM PMOS_6P0_DXL=0
-.PARAM PMOS_6P0_DXW=0
-.PARAM PMOS_6P0_DTOX=0
-.PARAM PMOS_6P0_DCGDO=1
-.PARAM PMOS_6P0_DCGSO=1
-.LIB sm141064.xyce nmos_6p0_t
-.LIB sm141064.xyce pmos_6p0_t
-.LIB sm141064.xyce nmos_6p0_nat_t
+.PARAM nfet_06v0_VSAT=1
+.PARAM nfet_06v0_VTH0=0
+.PARAM nfet_06v0_XL=0
+.PARAM nfet_06v0_XW=0
+.PARAM nfet_06v0_TOX=0
+.PARAM nfet_06v0_CGSO=1
+.PARAM nfet_06v0_CGDO=1
+.PARAM nfet_06v0_nvt_U0='0.070102'
+.PARAM nfet_06v0_nvt_VTH0='-0.039'
+.PARAM nfet_06v0_nvt_XL='0'
+.PARAM nfet_06v0_nvt_XW='0'
+.PARAM nfet_06v0_nvt_TOX='1.52e-008'
+.PARAM nfet_06v0_nvt_CGSO='1e-010'
+.PARAM nfet_06v0_nvt_CGDO='1e-010'
+.PARAM pfet_06v0_DVTH0=0
+.PARAM pfet_06v0_DXL=0
+.PARAM pfet_06v0_DXW=0
+.PARAM pfet_06v0_DTOX=0
+.PARAM pfet_06v0_DCGDO=1
+.PARAM pfet_06v0_DCGSO=1
+.LIB sm141064.xyce nfet_06v0_t
+.LIB sm141064.xyce pfet_06v0_t
+.LIB sm141064.xyce nfet_06v0_nvt_t
 .LIB sm141064.xyce noise_corner
 .LIB sm141064.xyce fets_mm
 .ENDL typical
 *
 *
 .LIB ff
-.LIB sm141064.xyce nmos_3p3_f
-.LIB sm141064.xyce pmos_3p3_f
+.LIB sm141064.xyce nfet_03v3_f
+.LIB sm141064.xyce pfet_03v3_f
 *
 .PARAM RSH_NPLUS_U_M=45
 .PARAM RSH_PPLUS_U_M=145
-.PARAM NMOS_6P0_VSAT=1.0846
-.PARAM NMOS_6P0_VTH0=-0.1298
-.PARAM NMOS_6P0_XL=-4.2E-8
-.PARAM NMOS_6P0_XW=5E-8
-.PARAM NMOS_6P0_TOX=-1E-9
-.PARAM NMOS_6P0_CGSO=0.9
-.PARAM NMOS_6P0_CGDO=0.9
-.PARAM NMOS_6P0_NAT_U0='0.118'
-.PARAM NMOS_6P0_NAT_VTH0='-0.216'
-.PARAM NMOS_6P0_NAT_XL='-2e-7'
-.PARAM NMOS_6P0_NAT_XW='1e-7'
-.PARAM NMOS_6P0_NAT_TOX='1.42e-008'
-.PARAM NMOS_6P0_NAT_CGSO='9e-011'
-.PARAM NMOS_6P0_NAT_CGDO='9e-011'
-.PARAM PMOS_6P0_DVTH0=0.1245
-.PARAM PMOS_6P0_DXL=-4.65E-8
-.PARAM PMOS_6P0_DXW=5E-8
-.PARAM PMOS_6P0_DTOX=-1E-9
-.PARAM PMOS_6P0_DCGDO=0.9
-.PARAM PMOS_6P0_DCGSO=0.9
-.LIB sm141064.xyce nmos_6p0_t
-.LIB sm141064.xyce pmos_6p0_t
-.LIB sm141064.xyce nmos_6p0_nat_t
+.PARAM nfet_06v0_VSAT=1.0846
+.PARAM nfet_06v0_VTH0=-0.1298
+.PARAM nfet_06v0_XL=-4.2E-8
+.PARAM nfet_06v0_XW=5E-8
+.PARAM nfet_06v0_TOX=-1E-9
+.PARAM nfet_06v0_CGSO=0.9
+.PARAM nfet_06v0_CGDO=0.9
+.PARAM nfet_06v0_nvt_U0='0.118'
+.PARAM nfet_06v0_nvt_VTH0='-0.216'
+.PARAM nfet_06v0_nvt_XL='-2e-7'
+.PARAM nfet_06v0_nvt_XW='1e-7'
+.PARAM nfet_06v0_nvt_TOX='1.42e-008'
+.PARAM nfet_06v0_nvt_CGSO='9e-011'
+.PARAM nfet_06v0_nvt_CGDO='9e-011'
+.PARAM pfet_06v0_DVTH0=0.1245
+.PARAM pfet_06v0_DXL=-4.65E-8
+.PARAM pfet_06v0_DXW=5E-8
+.PARAM pfet_06v0_DTOX=-1E-9
+.PARAM pfet_06v0_DCGDO=0.9
+.PARAM pfet_06v0_DCGSO=0.9
+.LIB sm141064.xyce nfet_06v0_t
+.LIB sm141064.xyce pfet_06v0_t
+.LIB sm141064.xyce nfet_06v0_nvt_t
 .LIB sm141064.xyce noise_corner
 .LIB sm141064.xyce fets_mm
 .ENDL ff
 *
 *
 .LIB ss
-.LIB sm141064.xyce nmos_3p3_s
-.LIB sm141064.xyce pmos_3p3_s
+.LIB sm141064.xyce nfet_03v3_s
+.LIB sm141064.xyce pfet_03v3_s
 *
 .PARAM RSH_NPLUS_U_M=75
 .PARAM RSH_PPLUS_U_M=225
-.PARAM NMOS_6P0_VSAT=0.899
-.PARAM NMOS_6P0_VTH0=0.1193
-.PARAM NMOS_6P0_XL=7E-8
-.PARAM NMOS_6P0_XW=-5E-8
-.PARAM NMOS_6P0_TOX=1E-9
-.PARAM NMOS_6P0_CGSO=1.1
-.PARAM NMOS_6P0_CGDO=1.1
-.PARAM NMOS_6P0_NAT_U0='0.046'
-.PARAM NMOS_6P0_NAT_VTH0='0.1417'
-.PARAM NMOS_6P0_NAT_XL='2e-7'
-.PARAM NMOS_6P0_NAT_XW='-1e-7'
-.PARAM NMOS_6P0_NAT_TOX='1.62e-008'
-.PARAM NMOS_6P0_NAT_CGSO='1.1e-010'
-.PARAM NMOS_6P0_NAT_CGDO='1.1e-010'
-.PARAM PMOS_6P0_DVTH0=-0.1225
-.PARAM PMOS_6P0_DXL=6.9E-8
-.PARAM PMOS_6P0_DXW=-5E-8
-.PARAM PMOS_6P0_DTOX=1E-9
-.PARAM PMOS_6P0_DCGDO=1.1
-.PARAM PMOS_6P0_DCGSO=1.1
-.LIB sm141064.xyce nmos_6p0_t
+.PARAM nfet_06v0_VSAT=0.899
+.PARAM nfet_06v0_VTH0=0.1193
+.PARAM nfet_06v0_XL=7E-8
+.PARAM nfet_06v0_XW=-5E-8
+.PARAM nfet_06v0_TOX=1E-9
+.PARAM nfet_06v0_CGSO=1.1
+.PARAM nfet_06v0_CGDO=1.1
+.PARAM nfet_06v0_nvt_U0='0.046'
+.PARAM nfet_06v0_nvt_VTH0='0.1417'
+.PARAM nfet_06v0_nvt_XL='2e-7'
+.PARAM nfet_06v0_nvt_XW='-1e-7'
+.PARAM nfet_06v0_nvt_TOX='1.62e-008'
+.PARAM nfet_06v0_nvt_CGSO='1.1e-010'
+.PARAM nfet_06v0_nvt_CGDO='1.1e-010'
+.PARAM pfet_06v0_DVTH0=-0.1225
+.PARAM pfet_06v0_DXL=6.9E-8
+.PARAM pfet_06v0_DXW=-5E-8
+.PARAM pfet_06v0_DTOX=1E-9
+.PARAM pfet_06v0_DCGDO=1.1
+.PARAM pfet_06v0_DCGSO=1.1
+.LIB sm141064.xyce nfet_06v0_t
 
-.LIB sm141064.xyce pmos_6p0_t
-.LIB sm141064.xyce nmos_6p0_nat_t
+.LIB sm141064.xyce pfet_06v0_t
+.LIB sm141064.xyce nfet_06v0_nvt_t
 .LIB sm141064.xyce noise_corner
 .LIB sm141064.xyce fets_mm
 .ENDL ss
 *
 *
 .LIB fs
-.LIB sm141064.xyce nmos_3p3_fs
-.LIB sm141064.xyce pmos_3p3_fs
+.LIB sm141064.xyce nfet_03v3_fs
+.LIB sm141064.xyce pfet_03v3_fs
 *
 .PARAM RSH_NPLUS_U_M=48
 .PARAM RSH_PPLUS_U_M=219
-.PARAM NMOS_6P0_VSAT='0.0846*0.67+1'
-.PARAM NMOS_6P0_VTH0='-0.1298*0.75'
-.PARAM NMOS_6P0_XL='-4.2E-8*0.67'
-.PARAM NMOS_6P0_XW='5E-8*0.67'
-.PARAM NMOS_6P0_TOX='-1E-9*0.75'
-.PARAM NMOS_6P0_CGSO=0.93
-.PARAM NMOS_6P0_CGDO=0.93
-.PARAM NMOS_6P0_NAT_U0='0.102034'
-.PARAM NMOS_6P0_NAT_VTH0='-0.157'
-.PARAM NMOS_6P0_NAT_XL='-1.33e-7'
-.PARAM NMOS_6P0_NAT_XW='6.7e-8'
-.PARAM NMOS_6P0_NAT_TOX='1.453e-008'
-.PARAM NMOS_6P0_NAT_CGSO='9.33e-011'
-.PARAM NMOS_6P0_NAT_CGDO='9.33e-011'
-.PARAM PMOS_6P0_DVTH0=-0.0829
-.PARAM PMOS_6P0_DXL=4.1E-8
-.PARAM PMOS_6P0_DXW=-3.35E-8
-.PARAM PMOS_6P0_DTOX=6.7E-10
-.PARAM PMOS_6P0_DCGDO=1.07
-.PARAM PMOS_6P0_DCGSO=1.07
-.LIB sm141064.xyce nmos_6p0_t
+.PARAM nfet_06v0_VSAT='0.0846*0.67+1'
+.PARAM nfet_06v0_VTH0='-0.1298*0.75'
+.PARAM nfet_06v0_XL='-4.2E-8*0.67'
+.PARAM nfet_06v0_XW='5E-8*0.67'
+.PARAM nfet_06v0_TOX='-1E-9*0.75'
+.PARAM nfet_06v0_CGSO=0.93
+.PARAM nfet_06v0_CGDO=0.93
+.PARAM nfet_06v0_nvt_U0='0.102034'
+.PARAM nfet_06v0_nvt_VTH0='-0.157'
+.PARAM nfet_06v0_nvt_XL='-1.33e-7'
+.PARAM nfet_06v0_nvt_XW='6.7e-8'
+.PARAM nfet_06v0_nvt_TOX='1.453e-008'
+.PARAM nfet_06v0_nvt_CGSO='9.33e-011'
+.PARAM nfet_06v0_nvt_CGDO='9.33e-011'
+.PARAM pfet_06v0_DVTH0=-0.0829
+.PARAM pfet_06v0_DXL=4.1E-8
+.PARAM pfet_06v0_DXW=-3.35E-8
+.PARAM pfet_06v0_DTOX=6.7E-10
+.PARAM pfet_06v0_DCGDO=1.07
+.PARAM pfet_06v0_DCGSO=1.07
+.LIB sm141064.xyce nfet_06v0_t
 
-.LIB sm141064.xyce pmos_6p0_t
-.LIB sm141064.xyce nmos_6p0_nat_t
+.LIB sm141064.xyce pfet_06v0_t
+.LIB sm141064.xyce nfet_06v0_nvt_t
 .LIB sm141064.xyce noise_corner
 .LIB sm141064.xyce fets_mm
 .ENDL fs
 *
 *
 .LIB sf
-.LIB sm141064.xyce nmos_3p3_sf
-.LIB sm141064.xyce pmos_3p3_sf
+.LIB sm141064.xyce nfet_03v3_sf
+.LIB sm141064.xyce pfet_03v3_sf
 *
 .PARAM RSH_NPLUS_U_M=72
 .PARAM RSH_PPLUS_U_M=150
-.PARAM NMOS_6P0_VSAT='1-(1-0.899)*0.67'
-.PARAM NMOS_6P0_VTH0='0.1193*0.75'
-.PARAM NMOS_6P0_XL='7E-8*0.67'
-.PARAM NMOS_6P0_XW='-5E-8*0.67'
-.PARAM NMOS_6P0_TOX='1E-9*0.75'
-.PARAM NMOS_6P0_CGSO=1.07
-.PARAM NMOS_6P0_CGDO=1.07
-.PARAM NMOS_6P0_NAT_U0='0.054034'
-.PARAM NMOS_6P0_NAT_VTH0='0.08147'
-.PARAM NMOS_6P0_NAT_XL='1.33e-7'
-.PARAM NMOS_6P0_NAT_XW='-6.7e-8'
-.PARAM NMOS_6P0_NAT_TOX='1.587e-008'
-.PARAM NMOS_6P0_NAT_CGSO='1.067e-010'
-.PARAM NMOS_6P0_NAT_CGDO='1.067e-010'
-.PARAM PMOS_6P0_DVTH0=0.0827
-.PARAM PMOS_6P0_DXL=-3.22E-8
-.PARAM PMOS_6P0_DXW=3.35E-8
-.PARAM PMOS_6P0_DTOX=-6.7E-10
-.PARAM PMOS_6P0_DCGDO=0.93
-.PARAM PMOS_6P0_DCGSO=0.93
-.LIB sm141064.xyce nmos_6p0_t
+.PARAM nfet_06v0_VSAT='1-(1-0.899)*0.67'
+.PARAM nfet_06v0_VTH0='0.1193*0.75'
+.PARAM nfet_06v0_XL='7E-8*0.67'
+.PARAM nfet_06v0_XW='-5E-8*0.67'
+.PARAM nfet_06v0_TOX='1E-9*0.75'
+.PARAM nfet_06v0_CGSO=1.07
+.PARAM nfet_06v0_CGDO=1.07
+.PARAM nfet_06v0_nvt_U0='0.054034'
+.PARAM nfet_06v0_nvt_VTH0='0.08147'
+.PARAM nfet_06v0_nvt_XL='1.33e-7'
+.PARAM nfet_06v0_nvt_XW='-6.7e-8'
+.PARAM nfet_06v0_nvt_TOX='1.587e-008'
+.PARAM nfet_06v0_nvt_CGSO='1.067e-010'
+.PARAM nfet_06v0_nvt_CGDO='1.067e-010'
+.PARAM pfet_06v0_DVTH0=0.0827
+.PARAM pfet_06v0_DXL=-3.22E-8
+.PARAM pfet_06v0_DXW=3.35E-8
+.PARAM pfet_06v0_DTOX=-6.7E-10
+.PARAM pfet_06v0_DCGDO=0.93
+.PARAM pfet_06v0_DCGSO=0.93
+.LIB sm141064.xyce nfet_06v0_t
 
-.LIB sm141064.xyce pmos_6p0_t
-.LIB sm141064.xyce nmos_6p0_nat_t
+.LIB sm141064.xyce pfet_06v0_t
+.LIB sm141064.xyce nfet_06v0_nvt_t
 .LIB sm141064.xyce noise_corner
 .LIB sm141064.xyce fets_mm
 .ENDL sf
@@ -491,7 +491,7 @@
 
 .PARAM MC_C_COX_1P5FF=0
 .PARAM MC_C_COX_2P0FF=0
-.LIB sm141064.xyce mim_cap
+.LIB sm141064_mim.xyce cap_mim_new
 
 .ENDL mimcap_typical
 *
@@ -502,7 +502,7 @@
 .PARAM MC_C_COX_1P0FF=0
 .PARAM MC_C_COX_1P5FF=0
 .PARAM MC_C_COX_2P0FF=0
-.LIB sm141064.xyce mim_cap
+.LIB sm141064_mim.xyce cap_mim_new
 
 .ENDL mimcap_ss
 *
@@ -514,15 +514,15 @@
 
 .PARAM MC_C_COX_1P5FF=0
 .PARAM MC_C_COX_2P0FF=0
-.LIB sm141064.xyce mim_cap
+.LIB sm141064_mim.xyce cap_mim_new
 
 .ENDL mimcap_ff
 ****************************************************
 *
 .LIB moscap_typical
 .PARAM
-+ NMOSCAP_3P3_CORNER=1 PMOSCAP_3P3_CORNER=1 NMOSCAP_6P0_CORNER=1 PMOSCAP_6P0_CORNER=1
-+ NMOSCAP_3P3_B_CORNER=1 PMOSCAP_3P3_B_CORNER=1 NMOSCAP_6P0_B_CORNER=1 PMOSCAP_6P0_B_CORNER=1
++ cap_nmos_03v3_CORNER=1 cap_pmos_03v3_CORNER=1 cap_nmos_06v0_CORNER=1 cap_pmos_06v0_CORNER=1
++ cap_nmos_03v3_b_CORNER=1 cap_pmos_03v3_b_CORNER=1 cap_nmos_06v0_b_CORNER=1 cap_pmos_06v0_b_CORNER=1
 .LIB sm141064.xyce moscap
 
 
@@ -535,8 +535,8 @@
 *
 .LIB moscap_ff
 .PARAM
-+ NMOSCAP_3P3_CORNER=0.9 PMOSCAP_3P3_CORNER=0.9 NMOSCAP_6P0_CORNER=0.9 PMOSCAP_6P0_CORNER=0.9
-+ NMOSCAP_3P3_B_CORNER=0.9 PMOSCAP_3P3_B_CORNER=0.9 NMOSCAP_6P0_B_CORNER=0.9 PMOSCAP_6P0_B_CORNER=0.9
++ cap_nmos_03v3_CORNER=0.9 cap_pmos_03v3_CORNER=0.9 cap_nmos_06v0_CORNER=0.9 cap_pmos_06v0_CORNER=0.9
++ cap_nmos_03v3_b_CORNER=0.9 cap_pmos_03v3_b_CORNER=0.9 cap_nmos_06v0_b_CORNER=0.9 cap_pmos_06v0_b_CORNER=0.9
 .LIB sm141064.xyce moscap
 
 
@@ -549,8 +549,8 @@
 *
 .LIB moscap_ss
 .PARAM
-+ NMOSCAP_3P3_CORNER=1.1 PMOSCAP_3P3_CORNER=1.1 NMOSCAP_6P0_CORNER=1.1 PMOSCAP_6P0_CORNER=1.1
-+ NMOSCAP_3P3_B_CORNER=1.1 PMOSCAP_3P3_B_CORNER=1.1 NMOSCAP_6P0_B_CORNER=1.1 PMOSCAP_6P0_B_CORNER=1.1
++ cap_nmos_03v3_CORNER=1.1 cap_pmos_03v3_CORNER=1.1 cap_nmos_06v0_CORNER=1.1 cap_pmos_06v0_CORNER=1.1
++ cap_nmos_03v3_b_CORNER=1.1 cap_pmos_03v3_b_CORNER=1.1 cap_nmos_06v0_b_CORNER=1.1 cap_pmos_06v0_b_CORNER=1.1
 .LIB sm141064.xyce moscap
 
 
@@ -614,33 +614,33 @@
 
 
 .PARAM
-+ NMOS_3P3_SIG_VTH1='(5e-3*mc_sig_vth+30e-3*mc_sig_vthN)*sw_stat_global*mc_skew' NMOS_3P3_SIG_VTH2='(5e-3*mc_sig_vth+25e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
-+ NMOS_3P3_SIG_VTH3='(5e-3*mc_sig_vth+15e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
-+ NMOS_3P3_TOX='8e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeN)*sw_stat_global*mc_skew'
-+ NMOS_3P3_XL='(7e-9*mc_xl+6e-9*mc_xlN)*sw_stat_global*mc_skew' NMOS_3P3_XW='(7e-9*mc_xw+3e-9*mc_xwN)*sw_stat_global*mc_skew'
-+ NMOS_3P3_XJ='1e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjN)*sw_stat_global*mc_skew' NMOS_3P3_RDSW='530 * (1+0.15* mc_rdswN*sw_stat_global*mc_skew)'
-+ NMOS_3P3_VTH0_0='0.70837662 + nmos_3p3_sig_vth1' NMOS_3P3_VTH0_1='0.67781184 + nmos_3p3_sig_vth1'
-+ NMOS_3P3_VTH0_2='0.66097097 + nmos_3p3_sig_vth2' NMOS_3P3_VTH0_3='0.66064857 + nmos_3p3_sig_vth2'
-+ NMOS_3P3_VTH0_4='0.72356597 + nmos_3p3_sig_vth1' NMOS_3P3_VTH0_5='0.67504024 + nmos_3p3_sig_vth2'
-+ NMOS_3P3_VTH0_6='0.64923469 + nmos_3p3_sig_vth2' NMOS_3P3_VTH0_7='0.65055971 + nmos_3p3_sig_vth3'
-+ NMOS_3P3_VTH0_8='0.75419347 + nmos_3p3_sig_vth2' NMOS_3P3_VTH0_9='0.66260505 + nmos_3p3_sig_vth2'
-+ NMOS_3P3_VTH0_10='0.64815901 + nmos_3p3_sig_vth3' NMOS_3P3_VTH0_11='0.64889718 + nmos_3p3_sig_vth3'
-+ NMOS_3P3_VTH0_12='0.74840818 + nmos_3p3_sig_vth2' NMOS_3P3_VTH0_13='0.66297571 + nmos_3p3_sig_vth3'
-+ NMOS_3P3_VTH0_14='0.64787864 + nmos_3p3_sig_vth3' NMOS_3P3_VTH0_15='0.64857 + nmos_3p3_sig_vth3'
++ nfet_03v3_SIG_VTH1='(5e-3*mc_sig_vth+30e-3*mc_sig_vthN)*sw_stat_global*mc_skew' nfet_03v3_SIG_VTH2='(5e-3*mc_sig_vth+25e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
++ nfet_03v3_SIG_VTH3='(5e-3*mc_sig_vth+15e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
++ nfet_03v3_TOX='8e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeN)*sw_stat_global*mc_skew'
++ nfet_03v3_XL='(7e-9*mc_xl+6e-9*mc_xlN)*sw_stat_global*mc_skew' nfet_03v3_XW='(7e-9*mc_xw+3e-9*mc_xwN)*sw_stat_global*mc_skew'
++ nfet_03v3_XJ='1e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjN)*sw_stat_global*mc_skew' nfet_03v3_RDSW='530 * (1+0.15* mc_rdswN*sw_stat_global*mc_skew)'
++ nfet_03v3_VTH0_0='0.70837662 + nfet_03v3_sig_vth1' nfet_03v3_VTH0_1='0.67781184 + nfet_03v3_sig_vth1'
++ nfet_03v3_VTH0_2='0.66097097 + nfet_03v3_sig_vth2' nfet_03v3_VTH0_3='0.66064857 + nfet_03v3_sig_vth2'
++ nfet_03v3_VTH0_4='0.72356597 + nfet_03v3_sig_vth1' nfet_03v3_VTH0_5='0.67504024 + nfet_03v3_sig_vth2'
++ nfet_03v3_VTH0_6='0.64923469 + nfet_03v3_sig_vth2' nfet_03v3_VTH0_7='0.65055971 + nfet_03v3_sig_vth3'
++ nfet_03v3_VTH0_8='0.75419347 + nfet_03v3_sig_vth2' nfet_03v3_VTH0_9='0.66260505 + nfet_03v3_sig_vth2'
++ nfet_03v3_VTH0_10='0.64815901 + nfet_03v3_sig_vth3' nfet_03v3_VTH0_11='0.64889718 + nfet_03v3_sig_vth3'
++ nfet_03v3_VTH0_12='0.74840818 + nfet_03v3_sig_vth2' nfet_03v3_VTH0_13='0.66297571 + nfet_03v3_sig_vth3'
++ nfet_03v3_VTH0_14='0.64787864 + nfet_03v3_sig_vth3' nfet_03v3_VTH0_15='0.64857 + nfet_03v3_sig_vth3'
 .PARAM
-+ PMOS_3P3_SIG_VTH1='(-5e-3*mc_sig_vth-38e-3*mc_sig_vthP)*sw_stat_global*mc_skew' PMOS_3P3_SIG_VTH2='(-5e-3*mc_sig_vth-30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
-+ PMOS_3P3_SIG_VTH3='(-5e-3*mc_sig_vth-18e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
-+ PMOS_3P3_TOX='7.9e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeP)*sw_stat_global*mc_skew'
-+ PMOS_3P3_XL='(7e-9*mc_xl+4e-9*mc_xlP)*sw_stat_global*mc_skew' PMOS_3P3_XW='(7e-9*mc_xw+3e-9*mc_xwP)*sw_stat_global*mc_skew'
-+ PMOS_3P3_XJ='1.0e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjP)*sw_stat_global*mc_skew' PMOS_3P3_RDSW='466 * (1+0.15*mc_rdswP*sw_stat_global*mc_skew)'
-+ PMOS_3P3_VTH0_0='-0.7506174 + pmos_3p3_sig_vth1' PMOS_3P3_VTH0_1='-0.78216327 + pmos_3p3_sig_vth1'
-+ PMOS_3P3_VTH0_2='-0.76745877 + pmos_3p3_sig_vth2' PMOS_3P3_VTH0_3='-0.76841429 + pmos_3p3_sig_vth2'
-+ PMOS_3P3_VTH0_4='-0.7710094 + pmos_3p3_sig_vth1' PMOS_3P3_VTH0_5='-0.77464237 + pmos_3p3_sig_vth2'
-+ PMOS_3P3_VTH0_6='-0.77376777 + pmos_3p3_sig_vth2' PMOS_3P3_VTH0_7='-0.77390514 + pmos_3p3_sig_vth3'
-+ PMOS_3P3_VTH0_8='-0.76226585 + pmos_3p3_sig_vth2' PMOS_3P3_VTH0_9='-0.76552347 + pmos_3p3_sig_vth2'
-+ PMOS_3P3_VTH0_10='-0.7677531 + pmos_3p3_sig_vth3' PMOS_3P3_VTH0_11='-0.7682 + pmos_3p3_sig_vth3'
-+ PMOS_3P3_VTH0_12='-0.76184364 + pmos_3p3_sig_vth2' PMOS_3P3_VTH0_13='-0.76642857 + pmos_3p3_sig_vth3'
-+ PMOS_3P3_VTH0_14='-0.76779091 + pmos_3p3_sig_vth3' PMOS_3P3_VTH0_15='-0.7682 + pmos_3p3_sig_vth3'
++ pfet_03v3_SIG_VTH1='(-5e-3*mc_sig_vth-38e-3*mc_sig_vthP)*sw_stat_global*mc_skew' pfet_03v3_SIG_VTH2='(-5e-3*mc_sig_vth-30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
++ pfet_03v3_SIG_VTH3='(-5e-3*mc_sig_vth-18e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
++ pfet_03v3_TOX='7.9e-009 + (1.6e-10*mc_toxe+0.3e-10*mc_toxeP)*sw_stat_global*mc_skew'
++ pfet_03v3_XL='(7e-9*mc_xl+4e-9*mc_xlP)*sw_stat_global*mc_skew' pfet_03v3_XW='(7e-9*mc_xw+3e-9*mc_xwP)*sw_stat_global*mc_skew'
++ pfet_03v3_XJ='1.0e-7 + (0.3e-9*mc_xj+0.7e-9*mc_xjP)*sw_stat_global*mc_skew' pfet_03v3_RDSW='466 * (1+0.15*mc_rdswP*sw_stat_global*mc_skew)'
++ pfet_03v3_VTH0_0='-0.7506174 + pfet_03v3_sig_vth1' pfet_03v3_VTH0_1='-0.78216327 + pfet_03v3_sig_vth1'
++ pfet_03v3_VTH0_2='-0.76745877 + pfet_03v3_sig_vth2' pfet_03v3_VTH0_3='-0.76841429 + pfet_03v3_sig_vth2'
++ pfet_03v3_VTH0_4='-0.7710094 + pfet_03v3_sig_vth1' pfet_03v3_VTH0_5='-0.77464237 + pfet_03v3_sig_vth2'
++ pfet_03v3_VTH0_6='-0.77376777 + pfet_03v3_sig_vth2' pfet_03v3_VTH0_7='-0.77390514 + pfet_03v3_sig_vth3'
++ pfet_03v3_VTH0_8='-0.76226585 + pfet_03v3_sig_vth2' pfet_03v3_VTH0_9='-0.76552347 + pfet_03v3_sig_vth2'
++ pfet_03v3_VTH0_10='-0.7677531 + pfet_03v3_sig_vth3' pfet_03v3_VTH0_11='-0.7682 + pfet_03v3_sig_vth3'
++ pfet_03v3_VTH0_12='-0.76184364 + pfet_03v3_sig_vth2' pfet_03v3_VTH0_13='-0.76642857 + pfet_03v3_sig_vth3'
++ pfet_03v3_VTH0_14='-0.76779091 + pfet_03v3_sig_vth3' pfet_03v3_VTH0_15='-0.7682 + pfet_03v3_sig_vth3'
 ****** 6.0V devices monte carlo parameters ******
 
 
@@ -667,20 +667,20 @@
 
 
 .PARAM
-+ NMOS_6P0_VSAT='(1-0.063* mc_rdswN*sw_stat_global*mc_skew)' NMOS_6P0_VTH0='(8e-3*mc_sig_vth+28e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
-+ NMOS_6P0_XL='(2e-8*mc_xl+0*mc_xlN)*sw_stat_global*mc_skew' NMOS_6P0_XW='(1.5e-8*mc_xw+9e-9*mc_xwN)*sw_stat_global*mc_skew'
-+ NMOS_6P0_TOX='(4e-10*mc_toxe+1.3e-10*mc_toxeN)*sw_stat_global*mc_skew' NMOS_6P0_CGSO=1
-+ NMOS_6P0_CGDO=1
++ nfet_06v0_VSAT='(1-0.063* mc_rdswN*sw_stat_global*mc_skew)' nfet_06v0_VTH0='(8e-3*mc_sig_vth+28e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
++ nfet_06v0_XL='(2e-8*mc_xl+0*mc_xlN)*sw_stat_global*mc_skew' nfet_06v0_XW='(1.5e-8*mc_xw+9e-9*mc_xwN)*sw_stat_global*mc_skew'
++ nfet_06v0_TOX='(4e-10*mc_toxe+1.3e-10*mc_toxeN)*sw_stat_global*mc_skew' nfet_06v0_CGSO=1
++ nfet_06v0_CGDO=1
 .PARAM
-+ PMOS_6P0_VTH0='-0.8978 + (8e-3*mc_sig_vth+30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
-+ PMOS_6P0_TOX='156e-010 + (4e-10*mc_toxe+1e-10*mc_toxeP)*sw_stat_global*mc_skew'
-+ PMOS_6P0_XL='0 + (2e-8*mc_xl+2e-9*mc_xlP)*sw_stat_global*mc_skew' PMOS_6P0_XW='0 + (1.5e-8*mc_xw+9e-9*mc_xwP)*sw_stat_global*mc_skew'
-+ PMOS_6P0_XJ='1.5e-7 + (0.3e-9*mc_xj+1e-8*mc_xjP)*sw_stat_global*mc_skew' PMOS_6P0_RDSW='1426 * (1+0.2* mc_rdswP*sw_stat_global*mc_skew)'
++ pfet_06v0_VTH0='-0.8978 + (8e-3*mc_sig_vth+30e-3*mc_sig_vthP)*sw_stat_global*mc_skew'
++ pfet_06v0_TOX='156e-010 + (4e-10*mc_toxe+1e-10*mc_toxeP)*sw_stat_global*mc_skew'
++ pfet_06v0_XL='0 + (2e-8*mc_xl+2e-9*mc_xlP)*sw_stat_global*mc_skew' pfet_06v0_XW='0 + (1.5e-8*mc_xw+9e-9*mc_xwP)*sw_stat_global*mc_skew'
++ pfet_06v0_XJ='1.5e-7 + (0.3e-9*mc_xj+1e-8*mc_xjP)*sw_stat_global*mc_skew' pfet_06v0_RDSW='1426 * (1+0.2* mc_rdswP*sw_stat_global*mc_skew)'
 .PARAM
-+ NMOS_6P0_NAT_VTH0='-0.039 + (8e-3*mc_sig_vth+60e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
-+ NMOS_6P0_NAT_TOX='152e-010 + (4e-10*mc_toxe+6e-10*mc_toxeN)*sw_stat_global*mc_skew'
-+ NMOS_6P0_NAT_XL='0 + (2e-8*mc_xl+8e-8*mc_xlN)*sw_stat_global*mc_skew' NMOS_6P0_NAT_XW='0 + (1.5e-8*mc_xw+8e-8*mc_xwN)*sw_stat_global*mc_skew'
-+ NMOS_6P0_NAT_XJ='1.5e-7 + (0.3e-9*mc_xj+2e-8*mc_xjN)*sw_stat_global*mc_skew' NMOS_6P0_NAT_RDSW='3480 * (1+0.2* mc_rdswN*sw_stat_global*mc_skew)'
++ nfet_06v0_nvt_VTH0='-0.039 + (8e-3*mc_sig_vth+60e-3*mc_sig_vthN)*sw_stat_global*mc_skew'
++ nfet_06v0_nvt_TOX='152e-010 + (4e-10*mc_toxe+6e-10*mc_toxeN)*sw_stat_global*mc_skew'
++ nfet_06v0_nvt_XL='0 + (2e-8*mc_xl+8e-8*mc_xlN)*sw_stat_global*mc_skew' nfet_06v0_nvt_XW='0 + (1.5e-8*mc_xw+8e-8*mc_xwN)*sw_stat_global*mc_skew'
++ nfet_06v0_nvt_XJ='1.5e-7 + (0.3e-9*mc_xj+2e-8*mc_xjN)*sw_stat_global*mc_skew' nfet_06v0_nvt_RDSW='3480 * (1+0.2* mc_rdswN*sw_stat_global*mc_skew)'
 
 
 
@@ -699,11 +699,11 @@
 
 
 
-.LIB sm141064.xyce nmos_3p3_stat
-.LIB sm141064.xyce pmos_3p3_stat
-.LIB sm141064.xyce nmos_6p0_t
-.LIB sm141064.xyce pmos_6p0_stat
-.LIB sm141064.xyce nmos_6p0_nat_stat
+.LIB sm141064.xyce nfet_03v3_stat
+.LIB sm141064.xyce pfet_03v3_stat
+.LIB sm141064.xyce nfet_06v0_t
+.LIB sm141064.xyce pfet_06v0_stat
+.LIB sm141064.xyce nfet_06v0_nvt_stat
 .LIB sm141064.xyce noise_corner
 .ENDL statistical
 
@@ -711,14 +711,14 @@
 *
 .LIB noise_corner
 .PARAM
-+ NMOS_3P3_NOIA='(fnoicor==0)*3.2e+041 + (fnoicor==1)*3.5e+042' NMOS_3P3_NOIB='(fnoicor==0)*1.2e+020 + (fnoicor==1)*1.2e+020'
-+ NMOS_3P3_NOIC='(fnoicor==0)*6.0e+008 + (fnoicor==1)*6.0e+008' PMOS_3P3_NOIA='(fnoicor==0)*3.2e+041 + (fnoicor==1)*4.0e+042'
-+ PMOS_3P3_NOIB='(fnoicor==0)*1.8e+020 + (fnoicor==1)*1.8e+020' PMOS_3P3_NOIC='(fnoicor==0)*3.0e+009 + (fnoicor==1)*6.0e+009'
-+ NMOS_6P0_NOIA='(fnoicor==0)*1.998e+041 + (fnoicor==1)*8e+041' NMOS_6P0_NOIB='(fnoicor==0)*1e+025 + (fnoicor==1)*4e+025'
-+ NMOS_6P0_NOIC='(fnoicor==0)*5e+008 + (fnoicor==1)*2e+009' PMOS_6P0_NOIA='(fnoicor==0)*6e+040 + (fnoicor==1)*2e+043'
-+ PMOS_6P0_NOIB='(fnoicor==0)*1.5945e+025 + (fnoicor==1)*1.5945e+025' PMOS_6P0_NOIC='(fnoicor==0)*1.0499e+009 + (fnoicor==1)*1.0499e+009'
-+ NMOS_6P0_NAT_NOIA='(fnoicor==0)*5.5e+040 + (fnoicor==1)*1e+041' NMOS_6P0_NAT_NOIB='(fnoicor==0)*2.5e+025 + (fnoicor==1)*9.5e+025'
-+ NMOS_6P0_NAT_NOIC='(fnoicor==0)*1e+007 + (fnoicor==1)*2e+007'
++ nfet_03v3_NOIA='(fnoicor==0)*3.2e+041 + (fnoicor==1)*3.5e+042' nfet_03v3_NOIB='(fnoicor==0)*1.2e+020 + (fnoicor==1)*1.2e+020'
++ nfet_03v3_NOIC='(fnoicor==0)*6.0e+008 + (fnoicor==1)*6.0e+008' pfet_03v3_NOIA='(fnoicor==0)*3.2e+041 + (fnoicor==1)*4.0e+042'
++ pfet_03v3_NOIB='(fnoicor==0)*1.8e+020 + (fnoicor==1)*1.8e+020' pfet_03v3_NOIC='(fnoicor==0)*3.0e+009 + (fnoicor==1)*6.0e+009'
++ nfet_06v0_NOIA='(fnoicor==0)*1.998e+041 + (fnoicor==1)*8e+041' nfet_06v0_NOIB='(fnoicor==0)*1e+025 + (fnoicor==1)*4e+025'
++ nfet_06v0_NOIC='(fnoicor==0)*5e+008 + (fnoicor==1)*2e+009' pfet_06v0_NOIA='(fnoicor==0)*6e+040 + (fnoicor==1)*2e+043'
++ pfet_06v0_NOIB='(fnoicor==0)*1.5945e+025 + (fnoicor==1)*1.5945e+025' pfet_06v0_NOIC='(fnoicor==0)*1.0499e+009 + (fnoicor==1)*1.0499e+009'
++ nfet_06v0_nvt_NOIA='(fnoicor==0)*5.5e+040 + (fnoicor==1)*1e+041' nfet_06v0_nvt_NOIB='(fnoicor==0)*2.5e+025 + (fnoicor==1)*9.5e+025'
++ nfet_06v0_nvt_NOIC='(fnoicor==0)*1e+007 + (fnoicor==1)*2e+007'
 .ENDL noise_corner
 
 
@@ -738,8 +738,8 @@
 * 3.3V NMOS Models
 ***************************************************************************************************
 *
-.LIB nmos_3p3_t
-.SUBCKT nmos_3p3_sab d g s b
+.LIB nfet_03v3_t
+.SUBCKT nfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -763,11 +763,11 @@ Xr1 d d1 b nplus_u_m1
 
 Xr2 s s1 b nplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b nmos_3p3
+M0 d1 g s1 b nfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
 
-.MODEL nmos_3p3.0 NMOS
+.MODEL nfet_03v3.0 NMOS
 + A0=0.11197377 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.32403844
 + ALPHA0=2.652013e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=19.905584
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -788,8 +788,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-3.8181818e-018 LUTE=9.0909091e-008 LVOFF=3.9354545e-009
 + LVSAT=-0.0027272727 LVTH0=-3.8715455e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.7450182e-015 PAGS=-1.2213818e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.7450182e-015 PAGS=-1.2213818e-014
 + PALPHA0=-1.3658182e-020 PARAMCHK=1 PBETA0=8.7272727e-016 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.3741 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=5.388e-015
@@ -814,7 +814,7 @@ M0 d1 g s1 b nmos_3p3
 + WUTE=1.0441558e-007 WVOFF=5.3064935e-009 WVSAT=-0.00021818182
 + WVTH0=-1.430587e-008 WW=0 WWL=0 WWN=1 XJ=1e-007 XL=0 XPART=0 XTIS=3 XW=0
 + LEVEL=14
-.MODEL nmos_3p3.1 NMOS
+.MODEL nfet_03v3.1 NMOS
 + A0=1.0861147 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.47870122
 + ALPHA0=6.5720816e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=22.625306
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -835,7 +835,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=5.1428571e-018 LVOFF=-2.8273469e-009 LVSAT=0.0017142857
 + LVTH0=-2.3433061e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=2.4627526e-014 PAGS=-9.9007347e-015 PALPHA0=1.8396735e-020
 + PARAMCHK=1 PBETA0=2.4538775e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.082893878 PDIBLC1=0.39 PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0
@@ -1014,7 +1014,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.2 NMOS
+.MODEL nfet_03v3.2 NMOS
 + A0=1.224418 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.25784649
 + ALPHA0=7.5243347e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.210162
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -1034,8 +1034,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-2.347987e-025 LUB1=-7.5296104e-025 LUC=-6.9921429e-018
 + LVOFF=1.3461039e-008 LVTH0=-3.224026e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-4.2919481e-014 PAGS=4.5191688e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-4.2919481e-014 PAGS=4.5191688e-014
 + PALPHA0=-9.043013e-018 PARAMCHK=1 PBETA0=-3.1184416e-013 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.18918506 PDIBLC1=0.39 PDIBLC2=0.00064013636
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=2.6091117e-015
@@ -1257,7 +1257,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.3 NMOS
+.MODEL nfet_03v3.3 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.27510429
 + ALPHA0=6.6776286e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.896857
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -1271,8 +1271,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.022847143 KT1=-0.332 KT1L=0 KT2=-0.021107143 KU0=0 KVSAT=0 KVTH0=0
 + LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0
 + LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0
-+ MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.18626143 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -1492,7 +1492,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.4 NMOS
+.MODEL nfet_03v3.4 NMOS
 + A0=0.10680558 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.35500309
 + ALPHA0=2.6500109e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=20.982852
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -1512,8 +1512,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-9.0230909e-026 LUB1=2.4878e-025 LUC=-3.4349127e-017 LVOFF=-9.2114546e-009
 + LVSAT=0.0042909091 LVTH0=-4.1979273e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.0504145e-015 PAGS=-1.3815011e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.0504145e-015 PAGS=-1.3815011e-014
 + PALPHA0=-2.4870109e-020 PARAMCHK=1 PBETA0=1.0555636e-013 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.45921829 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=3.5791331e-015
@@ -1693,7 +1693,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.5 NMOS
+.MODEL nfet_03v3.5 NMOS
 + A0=0.97533082 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.441074
 + ALPHA0=6.8164074e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.036008
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -1714,7 +1714,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=3.1443869e-017 LVOFF=1.1378694e-008 LVSAT=-0.0041142857
 + LVTH0=-1.7716408e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.4148441e-015 PAGS=-2.7963977e-014 PALPHA0=6.6303478e-020
 + PARAMCHK=1 PBETA0=-2.8990433e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.21719837 PDIBLC1=0.39 PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0
@@ -1932,7 +1932,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.6 NMOS
+.MODEL nfet_03v3.6 NMOS
 + A0=1.2333595 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.28370796
 + ALPHA0=9.0921047e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.039866
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -1953,7 +1953,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-5.0024338e-017 LUTE=3.448052e-007 LVOFF=1.3159091e-008
 + LVTH0=1.325026e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PAGS=6.3697932e-014 PALPHA0=-1.0548281e-019 PARAMCHK=1
 + PBETA0=-2.9791169e-014 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22708279
 + PDIBLC1=0.39 PDIBLC2=0.00064013636 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -2175,7 +2175,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.7 NMOS
+.MODEL nfet_03v3.7 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29711029
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.6678 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1e-010
@@ -2189,8 +2189,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.3443 KT1L=0 KT2=-0.022435714 KU0=0 KVSAT=0 KVTH0=0 LINT=0
 + LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0
 + LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22998886 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -2413,7 +2413,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.8 NMOS
+.MODEL nfet_03v3.8 NMOS
 + A0=0.10362636 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.2705431
 + ALPHA0=2.5953123e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.140586
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -2434,7 +2434,7 @@ M0 d1 g s1 b nmos_3p3
 + LVOFF=6.8691116e-010 LVOFFCV=-1.118626e-007 LVSAT=-0.00034132231
 + LVTH0=-5.5747725e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01
-+ NOFF=-0.59809917 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic}
++ NOFF=-0.59809917 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PAGS=-6.6365124e-014 PALPHA0=-5.7142305e-020 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.20476889 PDIBLC1=0.39
 + PDIBLC2=0.003171 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -2610,7 +2610,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.9 NMOS
+.MODEL nfet_03v3.9 NMOS
 + A0=0.57970277 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.63340774
 + ALPHA0=6.7040286e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.043581
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -2630,8 +2630,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB1=-6.899552e-025 LUC=5.1261039e-019 LUC1=7.5986727e-018
 + LVOFF=-1.0167857e-008 LVTH0=-9.953513e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-2.3401007e-013 PAGS=8.279421e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-2.3401007e-013 PAGS=8.279421e-014
 + PARAMCHK=1 PBETA0=-4.8405592e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.047719 PDIBLC1=0.39 PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0
 + PDITSL=0 PERMOD=1 PHIN=0.07 PK2=7.3331031e-015 PKT1=2.1335166e-014
@@ -2856,7 +2856,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.10 NMOS
+.MODEL nfet_03v3.10 NMOS
 + A0=1.175342 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26729169
 + ALPHA0=9.0929986e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.512311
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -2878,7 +2878,7 @@ M0 d1 g s1 b nmos_3p3
 + LUTE=-2.7427686e-008 LVOFF=1.3159091e-008 LVOFFCV=8.5056818e-008
 + LVTH0=7.3817355e-009 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01
-+ NOFF=2.128874 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic}
++ NOFF=2.128874 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PA0=2.454613e-013 PAGS=-1.211339e-013 PARAMCHK=1
 + PBETA0=4.3431558e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23344442
 + PDIBLC1=0.39 PDIBLC2=0.00064013636 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -3091,7 +3091,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.11 NMOS
+.MODEL nfet_03v3.11 NMOS
 + A0=1.0799807 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29635773
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.100914
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -3106,7 +3106,7 @@ M0 d1 g s1 b nmos_3p3
 + LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0
 + LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0
 + MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1134091
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803
 + PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0
@@ -3336,7 +3336,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.12 NMOS
+.MODEL nfet_03v3.12 NMOS
 + A0=0.13211844 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.46155061
 + ALPHA0=2.6067636e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -3357,7 +3357,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.3852454e-017 LVOFFCV=-9.8636364e-008 LVTH0=-5.3919091e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
 + NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=-0.29090909
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=1.4217547e-013 PAGS=8.8676235e-013 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23286727 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PKETA=1.7976533e-014
@@ -3536,7 +3536,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.13 NMOS
+.MODEL nfet_03v3.13 NMOS
 + A0=0.62659857 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.61681571
 + ALPHA0=6.7040286e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -3555,8 +3555,8 @@ M0 d1 g s1 b nmos_3p3
 + LU0=4.4168571e-009 LUA=4.2286286e-016 LUB=-2.1651429e-025 LUB1=-6.3214286e-025
 + LUC1=8.9057143e-018 LVOFF=-8.2714286e-009 LVTH0=-1.1202857e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.065697143 PDIBLC1=0.39
 + PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -3746,7 +3746,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.14 NMOS
+.MODEL nfet_03v3.14 NMOS
 + A0=1.1822018 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26772773
 + ALPHA0=9.0929986e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.476046
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -3767,8 +3767,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB1=-1.5190909e-024 LUC=5.52e-017 LUC1=-1.0305e-016 LVOFF=1.3159091e-008
 + LVOFFCV=7.5e-008 LVTH0=6.9136364e-009 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071
 + MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019
-+ NJS=1.01 NOFF=2.1136364 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NJS=1.01 NOFF=2.1136364 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.23108545 PDIBLC1=0.39 PDIBLC2=0.00064013636 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
@@ -3948,7 +3948,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.15 NMOS
+.MODEL nfet_03v3.15 NMOS
 + A0=1.0893 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29558
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.069 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1e-010
@@ -3962,8 +3962,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.31717 KT1L=0 KT2=-0.018 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0
 + LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -4385,12 +4385,12 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS nplus_u_m1
-.ENDL nmos_3p3_t
+.ENDL nfet_03v3_t
 
 *
 *
-.LIB nmos_3p3_f
-.SUBCKT nmos_3p3_sab d g s b
+.LIB nfet_03v3_f
+.SUBCKT nfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -4413,10 +4413,10 @@ Xr1 d d1 b nplus_u_m1
 
 Xr2 s s1 b nplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b nmos_3p3
+M0 d1 g s1 b nfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL nmos_3p3.0 NMOS
+.MODEL nfet_03v3.0 NMOS
 + A0=0.11226647 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.31756239
 + ALPHA0=2.6143989e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=19.904932
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -4437,8 +4437,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-3.6804886e-018 LUTE=8.7630682e-008 LVOFF=3.7549747e-009
 + LVSAT=-0.0026289205 LVTH0=-3.5583899e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.717132e-015 PAGS=-1.2018636e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.717132e-015 PAGS=-1.2018636e-014
 + PALPHA0=-1.3439918e-020 PARAMCHK=1 PBETA0=8.5878068e-016 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.36674716 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=5.3018972e-015
@@ -4464,7 +4464,7 @@ M0 d1 g s1 b nmos_3p3
 + WVTH0=-1.5283991e-008 WW=0 WWL=0 WWN=1 XJ=1e-007 XL=-1.5e-008 XPART=0 XTIS=3
 + XW=1e-008
 + LEVEL=14
-.MODEL nmos_3p3.1 NMOS
+.MODEL nfet_03v3.1 NMOS
 + A0=1.0792115 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.47190495
 + ALPHA0=6.5170032e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=22.630402
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -4485,7 +4485,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC=1.0421037e-017 LUC1=5.172525e-018 LVOFF=-2.7402067e-009 LVSAT=0.0014368125
 + LVTH0=-2.2389644e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=2.528563e-014 PAGS=-1.0165305e-014 PALPHA0=1.8888337e-020
 + PARAMCHK=1 PBETA0=2.5194507e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.080786018 PDIBLC1=0.39 PDIBLC2=0.00138165 PDIBLCB=0.2 PDITS=0 PDITSD=0
@@ -4662,7 +4662,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.2 NMOS
+.MODEL nfet_03v3.2 NMOS
 + A0=1.2231563 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.25832779
 + ALPHA0=7.4353703e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.194431
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -4682,8 +4682,8 @@ M0 d1 g s1 b nmos_3p3
 + LU0=-1.8007167e-009 LUA=1.9094925e-016 LUB=-2.2003905e-025 LUB1=-7.5507747e-025
 + LUC=-7.0384932e-018 LVOFF=1.3287723e-008 LVTH0=-2.8000692e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-4.536112e-014
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-4.536112e-014
 + PAGS=4.7762591e-014 PALPHA0=-9.5574596e-018 PARAMCHK=1 PBETA0=-3.2958461e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.18891787 PDIBLC1=0.39
 + PDIBLC2=0.00064234716 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -4905,7 +4905,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.3 NMOS
+.MODEL nfet_03v3.3 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.274905
 + ALPHA0=6.60855e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.88825
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -4920,7 +4920,7 @@ M0 d1 g s1 b nmos_3p3
 + KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0
 + LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1
 + MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.185545
 + PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0
@@ -5140,7 +5140,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.4 NMOS
+.MODEL nfet_03v3.4 NMOS
 + A0=0.10668786 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.3531832
 + ALPHA0=2.618997e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=20.979752
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -5160,8 +5160,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-7.8888061e-026 LUB1=2.2901987e-025 LUC=-3.141186e-017
 + LVOFF=-8.5346442e-009 LVSAT=0.0039725909 LVTH0=-3.8570937e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=9.9275047e-016
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=9.9275047e-016
 + PAGS=-1.3056615e-014 PALPHA0=-2.3504827e-020 PARAMCHK=1 PBETA0=9.9761689e-014
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.45094152 PDIBLC1=0.39
 + PDIBLC2=0.003171 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -5341,7 +5341,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.5 NMOS
+.MODEL nfet_03v3.5 NMOS
 + A0=0.9644116 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.43863251
 + ALPHA0=6.7595967e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.025956
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -5362,8 +5362,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-3.412717e-025 LUB1=-1.6787717e-025 LUC=4.0251276e-018 LUC1=3.0374545e-017
 + LVOFF=1.1009268e-008 LVSAT=-0.004023075 LVTH0=-1.6914157e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-1.3952024e-015 PAGS=-2.7575765e-014 PALPHA0=6.5383015e-020 PARAMCHK=1
 + PBETA0=-2.8587971e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21857359
 + PDIBLC1=0.39 PDIBLC2=0.00138165 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
@@ -5580,7 +5580,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.6 NMOS
+.MODEL nfet_03v3.6 NMOS
 + A0=1.2324275 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.28413926
 + ALPHA0=9.079175e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.031764
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -5602,7 +5602,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-4.9742943e-017 LUTE=3.4286561e-007 LVOFF=1.297511e-008
 + LVTH0=1.3266882e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PAGS=6.4659197e-014 PALPHA0=-1.0707464e-019 PARAMCHK=1
 + PBETA0=-3.0240747e-014 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22740181
 + PDIBLC1=0.39 PDIBLC2=0.00064234716 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -5823,7 +5823,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.7 NMOS
+.MODEL nfet_03v3.7 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.297263
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.6644 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=9e-011
@@ -5837,8 +5837,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.3443 KT1L=0 KT2=-0.02245 KU0=0 KVSAT=0 KVTH0=0 LINT=0
 + LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0
 + LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.230238 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -6061,7 +6061,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.8 NMOS
+.MODEL nfet_03v3.8 NMOS
 + A0=0.10353977 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.27394573
 + ALPHA0=2.567968e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.141066
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -6082,8 +6082,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.5702115e-017 LVOFF=6.3595312e-010 LVOFFCV=-1.0279677e-007
 + LVSAT=-0.00031600155 LVTH0=-5.1192629e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=-0.46137913 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NGATE=6e+019 NJS=1.01 NOFF=-0.46137913 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PAGS=-6.1503437e-014 PALPHA0=-5.2956251e-020 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.20348625 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK1=-4.7984203e-015
@@ -6258,7 +6258,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.9 NMOS
+.MODEL nfet_03v3.9 NMOS
 + A0=0.57333915 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.62982962
 + ALPHA0=6.6463107e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.044461
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -6278,8 +6278,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=3.7138544e-016 LUB=-1.6300526e-025 LUB1=-6.6136013e-025 LUC=4.9517784e-019
 + LUC1=7.2679686e-018 LVOFF=-9.7549306e-009 LVTH0=-9.5240796e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-2.262785e-013
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-2.262785e-013
 + PAGS=8.0058731e-014 PARAMCHK=1 PBETA0=-4.6806296e-013 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.049284973 PDIBLC1=0.39 PDIBLC2=0.00138165
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=7.0908211e-015
@@ -6504,7 +6504,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.10 NMOS
+.MODEL nfet_03v3.10 NMOS
 + A0=1.1740916 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26765145
 + ALPHA0=9.0800762e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.507475
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -6526,8 +6526,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC=6.3166633e-017 LUC1=-1.1139275e-016 LUTE=-2.7273401e-008
 + LVOFF=1.297511e-008 LVOFFCV=8.3951653e-008 LVTH0=7.2824411e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1288096 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=2.4432511e-013
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1288096 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=2.4432511e-013
 + PAGS=-1.205732e-013 PARAMCHK=1 PBETA0=4.3230522e-013 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.23327148 PDIBLC1=0.39 PDIBLC2=0.00064234716 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK1=3.632817e-015
@@ -6739,7 +6739,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.11 NMOS
+.MODEL nfet_03v3.11 NMOS
 + A0=1.0799017 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29636432
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.101184
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -6754,8 +6754,8 @@ M0 d1 g s1 b nmos_3p3
 + KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005
 + LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071
 + MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019
-+ NJS=1.01 NOFF=2.1135227 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NJS=1.01 NOFF=2.1135227 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
 + PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=530 RDSWMIN=50
@@ -6984,7 +6984,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.12 NMOS
+.MODEL nfet_03v3.12 NMOS
 + A0=0.13050819 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.45484419
 + ALPHA0=2.5788977e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -7005,7 +7005,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.0258119e-017 LVOFFCV=-9.0551705e-008 LVTH0=-4.9499651e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
 + NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=-0.16818182
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=1.3066601e-013 PAGS=8.1497672e-013 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23118796 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PKETA=1.6521288e-014
@@ -7184,7 +7184,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.13 NMOS
+.MODEL nfet_03v3.13 NMOS
 + A0=0.62004121 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.61330614
 + ALPHA0=6.6463107e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -7204,8 +7204,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-2.0739362e-025 LUB1=-6.0551384e-025 LUC1=8.5305611e-018
 + LVOFF=-7.9229946e-009 LVTH0=-1.0730937e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.067394929 PDIBLC1=0.39 PDIBLC2=0.00138165 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
@@ -7394,7 +7394,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.14 NMOS
+.MODEL nfet_03v3.14 NMOS
 + A0=1.1810406 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26807588
 + ALPHA0=9.0800762e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.470957
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -7416,8 +7416,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC=5.4428235e-017 LUC1=-1.0160923e-016 LVOFF=1.297511e-008
 + LVOFFCV=7.3951406e-008 LVTH0=6.8169751e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2.1134659 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2.1134659 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.23092226 PDIBLC1=0.39 PDIBLC2=0.00064234716 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
@@ -7596,7 +7596,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.15 NMOS
+.MODEL nfet_03v3.15 NMOS
 + A0=1.0893 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29558
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.069 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=9e-011
@@ -7610,8 +7610,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.31717 KT1L=0 KT2=-0.018 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0
 + LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -8032,13 +8032,13 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS nplus_u_m1
-.ENDL nmos_3p3_f
+.ENDL nfet_03v3_f
 
 
 *
 *
-.LIB nmos_3p3_s
-.SUBCKT nmos_3p3_sab d g s b
+.LIB nfet_03v3_s
+.SUBCKT nfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -8062,10 +8062,10 @@ Xr1 d d1 b nplus_u_m1
 
 Xr2 s s1 b nplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b nmos_3p3
+M0 d1 g s1 b nfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL nmos_3p3.0 NMOS
+.MODEL nfet_03v3.0 NMOS
 + A0=0.11164211 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.33078713
 + ALPHA0=2.689932e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=19.906217
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -8086,8 +8086,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-3.9362386e-018 LUTE=9.3719968e-008 LVOFF=4.1027149e-009
 + LVSAT=-0.002811599 LVTH0=-4.1963855e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.7614949e-015 PAGS=-1.2329143e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.7614949e-015 PAGS=-1.2329143e-014
 + PALPHA0=-1.3787144e-020 PARAMCHK=1 PBETA0=8.809677e-016 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.38126164 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=5.4388743e-015
@@ -8113,7 +8113,7 @@ M0 d1 g s1 b nmos_3p3
 + WVTH0=-1.335093e-008 WW=0 WWL=0 WWN=1 XJ=1e-007 XL=1.5e-008 XPART=0 XTIS=3
 + XW=-1e-008
 + LEVEL=14
-.MODEL nmos_3p3.1 NMOS
+.MODEL nfet_03v3.1 NMOS
 + A0=1.0928896 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.48554907
 + ALPHA0=6.6270642e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=22.618932
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -8134,8 +8134,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-6.8218008e-025 LUB1=-4.1622844e-025 LUC=8.7468885e-018 LUC1=5.0951893e-018
 + LVOFF=-2.9137715e-009 LVSAT=0.0020112589 LVTH0=-2.4499049e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=2.3890942e-014
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=2.3890942e-014
 + PAGS=-9.6046138e-015 PALPHA0=1.7846507e-020 PARAMCHK=1 PBETA0=2.3804846e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.085016691 PDIBLC1=0.39
 + PDIBLC2=0.00133635 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -8310,7 +8310,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.2 NMOS
+.MODEL nfet_03v3.2 NMOS
 + A0=1.2256909 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.25735343
 + ALPHA0=7.6135347e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.225975
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -8330,8 +8330,8 @@ M0 d1 g s1 b nmos_3p3
 + LU0=-1.5461646e-009 LUA=2.0053373e-016 LUB=-2.4989307e-025 LUB1=-7.505138e-025
 + LUC=-6.9419625e-018 LVOFF=1.3634437e-008 LVTH0=-3.6588628e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-4.0483744e-014 PAGS=4.2627001e-014 PALPHA0=-8.5298102e-018 PARAMCHK=1
 + PBETA0=-2.9414659e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.18943996
 + PDIBLC1=0.39 PDIBLC2=0.00063792557 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -8553,7 +8553,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.3 NMOS
+.MODEL nfet_03v3.3 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.27530357
 + ALPHA0=6.7467071e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.905464
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -8568,8 +8568,8 @@ M0 d1 g s1 b nmos_3p3
 + KT2=-0.021089286 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005
 + LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.18697786 PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
 + PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=530 RDSWMIN=50
@@ -8788,7 +8788,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.4 NMOS
+.MODEL nfet_03v3.4 NMOS
 + A0=0.10691933 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.35687524
 + ALPHA0=2.6811189e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=20.985552
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -8808,8 +8808,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=4.3347724e-016 LUB=-1.0258242e-025 LUB1=2.6922491e-025 LUC=-3.7418989e-017
 + LVOFF=-9.9036356e-009 LVSAT=0.0046169416 LVTH0=-4.5516631e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.1066809e-015
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.1066809e-015
 + PAGS=-1.4555024e-014 PALPHA0=-2.6202298e-020 PARAMCHK=1 PBETA0=1.1121058e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.46740308 PDIBLC1=0.39
 + PDIBLC2=0.003171 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -8989,7 +8989,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.5 NMOS
+.MODEL nfet_03v3.5 NMOS
 + A0=0.98625128 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.44354017
 + ALPHA0=6.8731595e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.046316
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -9010,8 +9010,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-3.8019306e-025 LUB1=-1.8386993e-025 LUC=4.040715e-018 LUC1=3.2514127e-017
 + LVOFF=1.1746901e-008 LVSAT=-0.0042012964 LVTH0=-1.8536912e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-1.432522e-015
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-1.432522e-015
 + PAGS=-2.8313377e-014 PALPHA0=6.7131915e-020 PARAMCHK=1 PBETA0=-2.9352658e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21580136 PDIBLC1=0.39
 + PDIBLC2=0.00133635 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -9228,7 +9228,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.6 NMOS
+.MODEL nfet_03v3.6 NMOS
 + A0=1.2342915 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.28327385
 + ALPHA0=9.1050349e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.04797
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -9250,7 +9250,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-5.0295738e-017 LUTE=3.4667589e-007 LVOFF=1.3343565e-008
 + LVTH0=1.3228401e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PAGS=6.2709277e-014 PALPHA0=-1.0384561e-019 PARAMCHK=1
 + PBETA0=-2.932878e-014 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22676292
 + PDIBLC1=0.39 PDIBLC2=0.00063792557 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -9471,7 +9471,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.7 NMOS
+.MODEL nfet_03v3.7 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29695757
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.6712 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1.1e-010
@@ -9485,8 +9485,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.3443 KT1L=0 KT2=-0.022421429 KU0=0 KVSAT=0 KVTH0=0 LINT=0
 + LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0
 + LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22973971 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -9709,7 +9709,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.8 NMOS
+.MODEL nfet_03v3.8 NMOS
 + A0=0.10371296 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26715255
 + ALPHA0=2.622667e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.140107
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -9730,7 +9730,7 @@ M0 d1 g s1 b nmos_3p3
 + LVOFF=7.3910414e-010 LVOFFCV=-1.2126927e-007 LVSAT=-0.00036725671
 + LVTH0=-6.047942e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01
-+ NOFF=-0.73454029 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic}
++ NOFF=-0.73454029 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PAGS=-7.1336137e-014 PALPHA0=-6.1422492e-020 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.2060622 PDIBLC1=0.39
 + PDIBLC2=0.003171 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -9906,7 +9906,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.9 NMOS
+.MODEL nfet_03v3.9 NMOS
 + A0=0.58607632 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.63698234
 + ALPHA0=6.7617464e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.042721
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -9926,8 +9926,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=4.0495747e-016 LUB=-1.7828226e-025 LUB1=-7.1902608e-025 LUC=5.3005815e-019
 + LUC1=7.9360174e-018 LVOFF=-1.0587044e-008 LVTH0=-1.0391311e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-2.4173263e-013 PAGS=8.5526499e-014 PARAMCHK=1 PBETA0=-5.0003024e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.046153372 PDIBLC1=0.39
 + PDIBLC2=0.00133635 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -10152,7 +10152,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.10 NMOS
+.MODEL nfet_03v3.10 NMOS
 + A0=1.1765919 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26693219
 + ALPHA0=9.1059211e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.517146
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -10174,8 +10174,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC=6.4809343e-017 LUC1=-1.1438687e-016 LUTE=-2.7576491e-008
 + LVOFF=1.3343565e-008 LVOFFCV=8.6162786e-008 LVTH0=7.4811957e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.128938 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=2.4654573e-013
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.128938 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=2.4654573e-013
 + PAGS=-1.2166906e-013 PARAMCHK=1 PBETA0=4.3623435e-013 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23361686 PDIBLC1=0.39 PDIBLC2=0.00063792557
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK1=3.6658349e-015
@@ -10387,7 +10387,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.11 NMOS
+.MODEL nfet_03v3.11 NMOS
 + A0=1.0800597 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29635114
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.100643
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -10402,8 +10402,8 @@ M0 d1 g s1 b nmos_3p3
 + KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005
 + LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071
 + MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019
-+ NJS=1.01 NOFF=2.1132954 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NJS=1.01 NOFF=2.1132954 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
 + PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=530 RDSWMIN=50
@@ -10632,7 +10632,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.12 NMOS
+.MODEL nfet_03v3.12 NMOS
 + A0=0.13372839 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.46825513
 + ALPHA0=2.6346295e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -10653,7 +10653,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.7587744e-017 LVOFFCV=-1.0703807e-007 LVTH0=-5.8511842e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
 + NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=-0.41363636
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=1.5411576e-013 PAGS=9.6123512e-013 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23454659 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PKETA=1.9486253e-014
@@ -10832,7 +10832,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.13 NMOS
+.MODEL nfet_03v3.13 NMOS
 + A0=0.63315593 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.62032529
 + ALPHA0=6.7617464e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -10852,8 +10852,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-2.2579734e-025 LUB1=-6.5924598e-025 LUC1=9.2875468e-018
 + LVOFF=-8.6260661e-009 LVTH0=-1.168318e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.063999357 PDIBLC1=0.39 PDIBLC2=0.00133635 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
@@ -11042,7 +11042,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.14 NMOS
+.MODEL nfet_03v3.14 NMOS
 + A0=1.1833631 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26737957
 + ALPHA0=9.1059211e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.481134
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -11064,8 +11064,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC=5.5973835e-017 LUC1=-1.0449463e-016 LVOFF=1.3343565e-008
 + LVOFFCV=7.6051406e-008 LVTH0=7.0105569e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2.1138068 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2.1138068 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.23124865 PDIBLC1=0.39 PDIBLC2=0.00063792557 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
@@ -11244,7 +11244,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.15 NMOS
+.MODEL nfet_03v3.15 NMOS
 + A0=1.0893 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29558
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.069 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1.1e-010
@@ -11258,8 +11258,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.31717 KT1L=0 KT2=-0.018 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0
 + LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -11681,12 +11681,12 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS nplus_u_m1
-.ENDL nmos_3p3_s
+.ENDL nfet_03v3_s
 
 *
 *
-.LIB nmos_3p3_fs
-.SUBCKT nmos_3p3_sab d g s b
+.LIB nfet_03v3_fs
+.SUBCKT nfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 
@@ -11711,10 +11711,10 @@ Xr1 d d1 b nplus_u_m1
 
 Xr2 s s1 b nplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b nmos_3p3
+M0 d1 g s1 b nfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL nmos_3p3.0 NMOS
+.MODEL nfet_03v3.0 NMOS
 + A0=0.11206719 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.32050776
 + ALPHA0=2.627733e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=19.907557
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -11735,8 +11735,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-3.6983864e-018 LUTE=8.8056818e-008 LVOFF=3.7921347e-009
 + LVSAT=-0.0026417045 LVTH0=-3.6607582e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.7078752e-015 PAGS=-1.1953845e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.7078752e-015 PAGS=-1.1953845e-014
 + PALPHA0=-1.3367465e-020 PARAMCHK=1 PBETA0=8.5415114e-016 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.36959505 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=5.2733156e-015
@@ -11761,7 +11761,7 @@ M0 d1 g s1 b nmos_3p3
 + WVOFF=5.3858974e-009 WVSAT=-0.00012912338 WVTH0=-1.4783981e-008 WW=0 WWL=0
 + WWN=1 XJ=1e-007 XL=-1e-008 XPART=0 XTIS=3 XW=5e-009
 + LEVEL=14
-.MODEL nmos_3p3.1 NMOS
+.MODEL nfet_03v3.1 NMOS
 + A0=1.0806312 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.47491359
 + ALPHA0=6.5351125e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=22.62283
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -11781,8 +11781,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=7.5232737e-016 LUB=-6.207519e-025 LUB1=-4.0025352e-025 LUC=9.9674311e-018
 + LUC1=5.12295e-018 LVOFF=-2.7639238e-009 LVSAT=0.001561875 LVTH0=-2.274447e-008
 + LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0
-+ MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=2.4787741e-014
++ MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=2.4787741e-014
 + PAGS=-9.965144e-015 PALPHA0=1.8516415e-020 PARAMCHK=1 PBETA0=2.4698413e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.082248339 PDIBLC1=0.39
 + PDIBLC2=0.0013741 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -11960,7 +11960,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.2 NMOS
+.MODEL nfet_03v3.2 NMOS
 + A0=1.2236495 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.25812408
 + ALPHA0=7.4780689e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.201637
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -11980,8 +11980,8 @@ M0 d1 g s1 b nmos_3p3
 + LU0=-1.7345577e-009 LUA=1.9286754e-016 LUB=-2.2684367e-025 LUB1=-7.5229142e-025
 + LUC=-6.999336e-018 LVOFF=1.3342993e-008 LVTH0=-3.0036269e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-4.4036219e-014 PAGS=4.6367549e-014 PALPHA0=-9.2783067e-018 PARAMCHK=1
 + PBETA0=-3.1995815e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.1890464
 + PDIBLC1=0.39 PDIBLC2=0.00064161023 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -12203,7 +12203,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.3 NMOS
+.MODEL nfet_03v3.3 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.27500464
 + ALPHA0=6.6430893e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.892554
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -12218,8 +12218,8 @@ M0 d1 g s1 b nmos_3p3
 + KT2=-0.021116071 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005
 + LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.18590321 PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
 + PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=530 RDSWMIN=50
@@ -12438,7 +12438,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.4 NMOS
+.MODEL nfet_03v3.4 NMOS
 + A0=0.10671673 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.35387843
 + ALPHA0=2.6294657e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=20.979738
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -12458,8 +12458,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=3.7738605e-016 LUB=-8.3236674e-026 LUB1=2.3542184e-025 LUC=-3.2397203e-017
 + LVOFF=-8.7450729e-009 LVSAT=0.0040720909 LVTH0=-3.9687122e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.0072317e-015
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.0072317e-015
 + PAGS=-1.3247072e-014 PALPHA0=-2.3847691e-020 PARAMCHK=1 PBETA0=1.0121691e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.45365742 PDIBLC1=0.39
 + PDIBLC2=0.003171 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -12639,7 +12639,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.5 NMOS
+.MODEL nfet_03v3.5 NMOS
 + A0=0.9680546 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.4396228
 + ALPHA0=6.7781531e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.030477
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -12660,7 +12660,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC=4.0042012e-018 LUC1=3.0687684e-017 LVOFF=1.1113945e-008 LVSAT=-0.00404005
 + LVTH0=-1.7189014e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.3952024e-015 PAGS=-2.7575765e-014 PALPHA0=6.5383015e-020
 + PARAMCHK=1 PBETA0=-2.8587971e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.2180583 PDIBLC1=0.39 PDIBLC2=0.0013741 PDIBLCB=0.2 PDITS=0 PDITSD=0
@@ -12878,7 +12878,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.6 NMOS
+.MODEL nfet_03v3.6 NMOS
 + A0=1.2327382 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.28395177
 + ALPHA0=9.0834879e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.03504
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -12900,7 +12900,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-4.9767852e-017 LUTE=3.430373e-007 LVOFF=1.3036382e-008
 + LVTH0=1.3228117e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PAGS=6.4031457e-014 PALPHA0=-1.0603512e-019 PARAMCHK=1
 + PBETA0=-2.9947156e-014 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22724843
 + PDIBLC1=0.39 PDIBLC2=0.00064161023 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -13121,7 +13121,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.7 NMOS
+.MODEL nfet_03v3.7 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29718664
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.6661 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=9.5e-011
@@ -13135,8 +13135,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.3443 KT1L=0 KT2=-0.022442857 KU0=0 KVSAT=0 KVTH0=0 LINT=0
 + LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0
 + LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23011343 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -13359,7 +13359,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.8 NMOS
+.MODEL nfet_03v3.8 NMOS
 + A0=0.10356864 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.27282829
 + ALPHA0=2.5770972e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.140826
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -13380,8 +13380,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.7020919e-017 LVOFF=6.518816e-010 LVOFFCV=-1.0576312e-007
 + LVSAT=-0.00032391632 LVTH0=-5.2688923e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=-0.50656508 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NGATE=6e+019 NJS=1.01 NOFF=-0.50656508 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PAGS=-6.3012337e-014 PALPHA0=-5.4255458e-020 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.2039517 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK1=-4.9161428e-015
@@ -13556,7 +13556,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.9 NMOS
+.MODEL nfet_03v3.9 NMOS
 + A0=0.57552494 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.63099948
 + ALPHA0=6.66555e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.044222
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -13576,8 +13576,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=3.7694084e-016 LUB=-1.6556982e-025 LUB1=-6.7075952e-025 LUC=5.0028276e-019
 + LUC1=7.3792611e-018 LVOFF=-9.8892719e-009 LVTH0=-9.668011e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-2.2849684e-013 PAGS=8.0843597e-014 PARAMCHK=1 PBETA0=-4.7265167e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.048788318 PDIBLC1=0.39
 + PDIBLC2=0.0013741 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -13802,7 +13802,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.10 NMOS
+.MODEL nfet_03v3.10 NMOS
 + A0=1.1745182 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.2675321
 + ALPHA0=9.0843837e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.509036
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -13824,8 +13824,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC=6.3428033e-017 LUC1=-1.1187747e-016 LUTE=-2.7287058e-008
 + LVOFF=1.3036382e-008 LVOFFCV=8.430588e-008 LVTH0=7.3148658e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1288096 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=2.4432511e-013
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1288096 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=2.4432511e-013
 + PAGS=-1.205732e-013 PARAMCHK=1 PBETA0=4.3230522e-013 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.23332588 PDIBLC1=0.39 PDIBLC2=0.00064161023 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK1=3.632817e-015
@@ -14037,7 +14037,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.11 NMOS
+.MODEL nfet_03v3.11 NMOS
 + A0=1.0799412 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29636102
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.101049
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -14052,8 +14052,8 @@ M0 d1 g s1 b nmos_3p3
 + KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005
 + LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071
 + MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019
-+ NJS=1.01 NOFF=2.1134659 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NJS=1.01 NOFF=2.1134659 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
 + PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=530 RDSWMIN=50
@@ -14282,7 +14282,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.12 NMOS
+.MODEL nfet_03v3.12 NMOS
 + A0=0.13104451 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.45707702
 + ALPHA0=2.5881864e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -14303,7 +14303,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.144057e-017 LVOFFCV=-9.3211364e-008 LVTH0=-5.0953541e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
 + NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=-0.20909091
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=1.3442985e-013 PAGS=8.3845218e-013 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23174773 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PKETA=1.6997185e-014
@@ -14482,7 +14482,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.13 NMOS
+.MODEL nfet_03v3.13 NMOS
 + A0=0.622227 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.614476
 + ALPHA0=6.66555e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=9.5e-011
@@ -14501,8 +14501,8 @@ M0 d1 g s1 b nmos_3p3
 + LU0=4.292449e-009 LUA=4.1095222e-016 LUB=-2.104158e-025 LUB1=-6.143375e-025
 + LUC1=8.65487e-018 LVOFF=-8.03845e-009 LVTH0=-1.088731e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.066829 PDIBLC1=0.39
 + PDIBLC2=0.0013741 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
 + PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0
@@ -14692,7 +14692,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.14 NMOS
+.MODEL nfet_03v3.14 NMOS
 + A0=1.1814276 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26795983
 + ALPHA0=9.0843837e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.472653
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -14714,8 +14714,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC=5.468526e-017 LUC1=-1.0208906e-016 LVOFF=1.3036382e-008
 + LVOFFCV=7.4300625e-008 LVTH0=6.8491667e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2.1135227 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2.1135227 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.23097666 PDIBLC1=0.39 PDIBLC2=0.00064161023 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
@@ -14894,7 +14894,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.15 NMOS
+.MODEL nfet_03v3.15 NMOS
 + A0=1.0893 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29558
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.069 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=9.5e-011
@@ -14908,8 +14908,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.31717 KT1L=0 KT2=-0.018 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0
 + LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -15332,14 +15332,14 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS nplus_u_m1
-.ENDL nmos_3p3_fs
+.ENDL nfet_03v3_fs
 
 
 
 *
 *
-.LIB nmos_3p3_sf
-.SUBCKT nmos_3p3_sab d g s b
+.LIB nfet_03v3_sf
+.SUBCKT nfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 
@@ -15364,10 +15364,10 @@ Xr1 d d1 b nplus_u_m1
 
 Xr2 s s1 b nplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b nmos_3p3
+M0 d1 g s1 b nfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL nmos_3p3.0 NMOS
+.MODEL nfet_03v3.0 NMOS
 + A0=0.11186736 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.32766
 + ALPHA0=2.6763946e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=19.903605
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -15388,8 +15388,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-3.9327954e-018 LUTE=9.3637987e-008 LVOFF=4.0757735e-009
 + LVSAT=-0.0028091396 LVTH0=-4.0876103e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.778677e-015 PAGS=-1.2449405e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.778677e-015 PAGS=-1.2449405e-014
 + PALPHA0=-1.3921628e-020 PARAMCHK=1 PBETA0=8.8956088e-016 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.37854122 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=5.4919265e-015
@@ -15414,7 +15414,7 @@ M0 d1 g s1 b nmos_3p3
 + WVOFF=5.2223358e-009 WVSAT=-0.00030073052 WVTH0=-1.3833002e-008 WW=0 WWL=0
 + WWN=1 XJ=1e-007 XL=1e-008 XPART=0 XTIS=3 XW=-5e-009
 + LEVEL=14
-.MODEL nmos_3p3.1 NMOS
+.MODEL nfet_03v3.1 NMOS
 + A0=1.0915554 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.48250605
 + ALPHA0=6.6090188e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=22.627356
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -15435,8 +15435,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-6.6750038e-025 LUB1=-4.1485807e-025 LUC=9.2670883e-018 LUC1=5.1571929e-018
 + LVOFF=-2.8907672e-009 LVSAT=0.0018733393 LVTH0=-2.4131129e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=2.4438924e-014
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=2.4438924e-014
 + PAGS=-9.8249129e-015 PALPHA0=1.8255849e-020 PARAMCHK=1 PBETA0=2.4350853e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.083544401 PDIBLC1=0.39
 + PDIBLC2=0.0013439 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -15613,7 +15613,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.2 NMOS
+.MODEL nfet_03v3.2 NMOS
 + A0=1.2251902 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.25756499
 + ALPHA0=7.5706791e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.218715
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -15633,8 +15633,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=1.9857306e-016 LUB=-2.4286628e-025 LUB1=-7.5352353e-025 LUC=-6.9837022e-018
 + LVOFF=1.3579168e-008 LVTH0=-3.4480652e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-4.1797436e-014 PAGS=4.4010242e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-4.1797436e-014 PAGS=4.4010242e-014
 + PALPHA0=-8.8066015e-018 PARAMCHK=1 PBETA0=-3.0369161e-013 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.18931963 PDIBLC1=0.39 PDIBLC2=0.0006386625
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=2.5409017e-015
@@ -15856,7 +15856,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.3 NMOS
+.MODEL nfet_03v3.3 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.27520393
 + ALPHA0=6.7121679e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.901161
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -15871,8 +15871,8 @@ M0 d1 g s1 b nmos_3p3
 + KT2=-0.021098214 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005
 + LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.18661964 PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
 + PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=530 RDSWMIN=50
@@ -16091,7 +16091,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.4 NMOS
+.MODEL nfet_03v3.4 NMOS
 + A0=0.10689312 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.35614518
 + ALPHA0=2.6705875e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=20.985833
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -16111,8 +16111,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=4.2195702e-016 LUB=-9.7593592e-026 LUB1=2.6245527e-025 LUC=-3.6357518e-017
 + LVOFF=-9.6862495e-009 LVSAT=0.0045138312 LVTH0=-4.4329423e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.0934756e-015
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.0934756e-015
 + PAGS=-1.4381348e-014 PALPHA0=-2.5889643e-020 PARAMCHK=1 PBETA0=1.0988358e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.46474849 PDIBLC1=0.39
 + PDIBLC2=0.003171 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -16292,7 +16292,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.5 NMOS
+.MODEL nfet_03v3.5 NMOS
 + A0=0.98260745 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.44253343
 + ALPHA0=6.854642e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.041625
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -16313,8 +16313,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-3.7282285e-025 LUB1=-1.8106533e-025 LUC=4.0692393e-018 LUC1=3.2202986e-017
 + LVOFF=1.1643984e-008 LVSAT=-0.0041874643 LVTH0=-1.8251362e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-1.4339074e-015 PAGS=-2.8340758e-014 PALPHA0=6.7196838e-020 PARAMCHK=1
 + PBETA0=-2.9381044e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21633117
 + PDIBLC1=0.39 PDIBLC2=0.0013439 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
@@ -16531,7 +16531,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.6 NMOS
+.MODEL nfet_03v3.6 NMOS
 + A0=1.2339809 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.28346322
 + ALPHA0=9.1007216e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.044693
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -16552,8 +16552,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC=-1.4725443e-017 LUC1=-5.0277701e-017 LUTE=3.4655156e-007
 + LVOFF=1.3282019e-008 LVTH0=1.3270713e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PAGS=6.3353669e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PAGS=6.3353669e-014
 + PALPHA0=-1.0491271e-019 PARAMCHK=1 PBETA0=-2.9630159e-014 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22691687 PDIBLC1=0.39 PDIBLC2=0.0006386625
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK1=-8.3293668e-015
@@ -16774,7 +16774,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.7 NMOS
+.MODEL nfet_03v3.7 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29703393
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.6695 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1.05e-010
@@ -16788,8 +16788,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.3443 KT1L=0 KT2=-0.022428571 KU0=0 KVSAT=0 KVTH0=0 LINT=0
 + LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0
 + LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22986429 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -17012,7 +17012,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.8 NMOS
+.MODEL nfet_03v3.8 NMOS
 + A0=0.10368409 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26826194
 + ALPHA0=2.6135308e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.140347
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -17033,8 +17033,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=5.2512691e-017 LVOFF=7.2259769e-010 LVOFFCV=-1.1811564e-007
 + LVSAT=-0.00035905475 LVTH0=-5.8885304e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=-0.68954029 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NGATE=6e+019 NJS=1.01 NOFF=-0.68954029 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PAGS=-6.977796e-014 PALPHA0=-6.0080856e-020 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.20558963 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK1=-5.4439881e-015
@@ -17209,7 +17209,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.9 NMOS
+.MODEL nfet_03v3.9 NMOS
 + A0=0.58388391 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.63581483
 + ALPHA0=6.7425071e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.042948
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -17229,8 +17229,8 @@ M0 d1 g s1 b nmos_3p3
 + LUA=3.9922365e-016 LUB=-1.7562456e-025 LUB1=-7.0936697e-025 LUC=5.249858e-019
 + LUC1=7.820931e-018 LVOFF=-1.0449376e-008 LVTH0=-1.0242633e-008 LW=0 LWL=0 LWN=1
 + MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017
-+ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-2.3953946e-013 PAGS=8.4750542e-014 PARAMCHK=1 PBETA0=-4.9549361e-013
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.046649798 PDIBLC1=0.39
 + PDIBLC2=0.0013439 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -17455,7 +17455,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.10 NMOS
+.MODEL nfet_03v3.10 NMOS
 + A0=1.1761657 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26705136
 + ALPHA0=9.1016136e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.515585
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -17477,8 +17477,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-1.1390135e-016 LUTE=-2.7566602e-008 LVOFF=1.3282019e-008
 + LVOFFCV=8.5808379e-008 LVTH0=7.4486913e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2.1289382 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=2.4658091e-013 PAGS=-1.2168642e-013
++ NGATE=6e+019 NJS=1.01 NOFF=2.1289382 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=2.4658091e-013 PAGS=-1.2168642e-013
 + PARAMCHK=1 PBETA0=4.362966e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.23356279 PDIBLC1=0.39 PDIBLC2=0.0006386625 PDIBLCB=0.2 PDITS=0 PDITSD=0
 + PDITSL=0 PERMOD=1 PHIN=0.07 PK1=3.666358e-015 PKT1=-5.3785472e-014
@@ -17690,7 +17690,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.11 NMOS
+.MODEL nfet_03v3.11 NMOS
 + A0=1.0800202 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29635443
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.100778
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -17705,8 +17705,8 @@ M0 d1 g s1 b nmos_3p3
 + KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005
 + LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071
 + MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019
-+ NJS=1.01 NOFF=2.1133523 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NJS=1.01 NOFF=2.1133523 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
 + PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=530 RDSWMIN=50
@@ -17935,7 +17935,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.12 NMOS
+.MODEL nfet_03v3.12 NMOS
 + A0=0.13319227 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.46602357
 + ALPHA0=2.6253409e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -17956,7 +17956,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.6326986e-017 LVOFFCV=-1.0420227e-007 LVTH0=-5.6961668e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
 + NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=-0.37272727
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=1.5011547e-013 PAGS=9.3628492e-013 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23398682 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PKETA=1.898046e-014
@@ -18135,7 +18135,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.13 NMOS
+.MODEL nfet_03v3.13 NMOS
 + A0=0.63097014 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.61915543
 + ALPHA0=6.7425071e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -18155,8 +18155,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-2.2268494e-025 LUB1=-6.5015893e-025 LUC1=9.1595271e-018
 + LVOFF=-8.5071643e-009 LVTH0=-1.1522139e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.064565286 PDIBLC1=0.39 PDIBLC2=0.0013439 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
@@ -18345,7 +18345,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.14 NMOS
+.MODEL nfet_03v3.14 NMOS
 + A0=1.182976 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26749563
 + ALPHA0=9.1016136e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.479438
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -18367,7 +18367,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-1.0401266e-016 LVOFF=1.3282019e-008 LVOFFCV=7.5700625e-008
 + LVTH0=6.9782212e-009 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01
-+ NOFF=2.11375 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic}
++ NOFF=2.11375 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.23119425 PDIBLC1=0.39 PDIBLC2=0.0006386625 PDIBLCB=0.2 PDITS=0 PDITSD=0
 + PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008
@@ -18547,7 +18547,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.15 NMOS
+.MODEL nfet_03v3.15 NMOS
 + A0=1.0893 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29558
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.069 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1.05e-010
@@ -18561,8 +18561,8 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.31717 KT1L=0 KT2=-0.018 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0
 + LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -18984,7 +18984,7 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS nplus_u_m1
-.ENDL nmos_3p3_sf
+.ENDL nfet_03v3_sf
 
 
 *
@@ -18992,8 +18992,8 @@ Rb 1 2
 * 3.3V PMOS Models
 ***************************************************************************************************
 *
-.LIB pmos_3p3_t
-.SUBCKT pmos_3p3_sab d g s b
+.LIB pfet_03v3_t
+.SUBCKT pfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -19017,10 +19017,10 @@ Xr1 d d1 b pplus_u_m1
 
 Xr2 s s1 b pplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_3p3
+M0 d1 g s1 b pfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_3p3.0 PMOS
+.MODEL pfet_03v3.0 PMOS
 + A0=1.0272635 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19081247
 + ALPHA0=1.1485698e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=39.773597
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -19042,7 +19042,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.6014546e-009 LVTH0=-7.6827273e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-2.7370909e-015 PAGS=-1.2080073e-014 PALPHA0=6.39288e-020
 + PARAMCHK=1 PBETA0=1.1827636e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.35627558 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -19067,7 +19067,7 @@ M0 d1 g s1 b pmos_3p3
 + WUC1=4.0843636e-017 WVOFF=-1.6655127e-009 WVTH0=4.2938493e-009 WW=0 WWL=0 WWN=1
 + XJ=1e-007 XL=0 XPART=0 XTIS=3 XW=0
 + LEVEL=14
-.MODEL pmos_3p3.1 PMOS
+.MODEL pfet_03v3.1 PMOS
 + A0=1.1510659 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19022326
 + ALPHA0=7.5504633e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=42.422959
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -19089,7 +19089,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.0738122e-017 LVOFF=1.2890571e-008 LVTH0=8.0902041e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.6645518e-014 PAGS=-3.0616751e-014 PALPHA0=-2.3899709e-018
 + PARAMCHK=1 PBETA0=8.5195102e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.25657102 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -19268,7 +19268,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.2 PMOS
+.MODEL pfet_03v3.2 PMOS
 + A0=1.2626103 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.15731682
 + ALPHA0=0.0020588939 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.45026
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -19291,7 +19291,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFFCV=-2.1818182e-007 LVTH0=-9.5551948e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=3.4170078e-014 PAGS=-1.4866597e-014 PALPHA0=-2.3332535e-017
 + PARAMCHK=1 PBETA0=-6.7464935e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.32143299 PDIBLC1=0.1484 PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0
@@ -19510,7 +19510,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.3 PMOS
+.MODEL pfet_03v3.3 PMOS
 + A0=1.2226 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17178714
 + ALPHA0=0.0018173857 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.712143
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -19527,7 +19527,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32571714
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -19756,7 +19756,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.4 PMOS
+.MODEL pfet_03v3.4 PMOS
 + A0=0.66833429 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20459958
 + ALPHA0=1.2079775e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.238696
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -19777,8 +19777,8 @@ M0 d1 g s1 b pmos_3p3
 + LUA1=-2.562e-016 LUB=-3.0903909e-025 LUB1=-2.9730909e-026 LUC=1.2453182e-017
 + LUC1=-3.4608e-017 LVTH0=-2.1407273e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-5.5371585e-014 PAGS=6.2401891e-015 PALPHA0=7.4403585e-020 PARAMCHK=1
 + PBETA0=-3.5411055e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3781492
 + PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
@@ -19963,7 +19963,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.5 PMOS
+.MODEL pfet_03v3.5 PMOS
 + A0=1.3454526 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19226653
 + ALPHA0=0.000123026 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.366204
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -19985,7 +19985,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.8185143e-017 LVOFF=1.2890571e-008 LVTH0=-3.242449e-010 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=7.4582136e-014 PAGS=-1.5349891e-014 PALPHA0=9.8215995e-018
 + PARAMCHK=1 PBETA0=2.571262e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.55246506 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -20204,7 +20204,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.6 PMOS
+.MODEL pfet_03v3.6 PMOS
 + A0=1.1189871 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16561084
 + ALPHA0=0.002173683 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.354662
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -20227,8 +20227,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-4.9745455e-017 LVOFF=-2.0507727e-008 LVOFFCV=-2.1818182e-007
 + LVTH0=-1.3737662e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-8.5520416e-014 PAGS=4.3007377e-015 PALPHA0=3.0854085e-017 PARAMCHK=1
 + PBETA0=-5.4377143e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3288581
 + PDIBLC1=0.1484 PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
@@ -20444,7 +20444,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.7 PMOS
+.MODEL pfet_03v3.7 PMOS
 + A0=1.1019943 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17639514
 + ALPHA0=0.0019217543 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.708143
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -20461,7 +20461,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -20687,7 +20687,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.8 PMOS
+.MODEL pfet_03v3.8 PMOS
 + A0=0.8879706 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.3341873
 + ALPHA0=9.723125e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.805966
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -20709,8 +20709,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.2857843e-025 LUC=-7.439668e-018 LUC1=8.8928926e-019
 + LVTH0=-8.7733719e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-1.5381528e-015 PAGS=9.42428e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-1.5381528e-015 PAGS=9.42428e-014
 + PALPHA0=-8.3139811e-019 PARAMCHK=1 PBETA0=-7.708444e-013 PBS=0.69939
 + PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32482036 PDIBLC1=0.1484 PDIBLC2=0.00073695
 + PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PK2=-2.2709854e-015
@@ -20892,7 +20892,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.9 PMOS
+.MODEL pfet_03v3.9 PMOS
 + A0=1.1782327 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20788505
 + ALPHA0=0.00011108151 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.187318
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -20915,7 +20915,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.787102e-009 LVTH0=-7.1445584e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.0756678e-013 PAGS=3.1315103e-015 PALPHA0=3.0672131e-018
 + PARAMCHK=1 PBETA0=-4.7627532e-015 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37778426 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -21136,7 +21136,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.10 PMOS
+.MODEL pfet_03v3.10 PMOS
 + A0=1.1832393 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16685819
 + ALPHA0=0.0021426891 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.161948
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -21159,8 +21159,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.3542397e-017 LVOFF=2.8431167e-009 LVOFFCV=-2.1818182e-007
 + LVTH0=-4.4690083e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=7.1205867e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=7.1205867e-014
 + PAGS=1.7427347e-015 PALPHA0=-3.7885537e-018 PARAMCHK=1 PBETA0=-8.2590471e-013
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.34313423 PDIBLC1=0.1484
 + PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0
@@ -21381,7 +21381,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.11 PMOS
+.MODEL pfet_03v3.11 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17785216
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.538555 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4e-011
@@ -21398,7 +21398,7 @@ M0 d1 g s1 b pmos_3p3
 + LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -21625,7 +21625,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.12 PMOS
+.MODEL pfet_03v3.12 PMOS
 + A0=0.88096455 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.31537636
 + ALPHA0=9.9689273e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.959273
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -21646,8 +21646,8 @@ M0 d1 g s1 b pmos_3p3
 + LU0=1.7741818e-009 LUA=6.4094546e-016 LUA1=-1.5476364e-016 LUB1=-1.3503636e-025
 + LUC=-5.67e-018 LVTH0=-8.0181818e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.33309909 PDIBLC1=0.1484
 + PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -21827,7 +21827,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.13 PMOS
+.MODEL pfet_03v3.13 PMOS
 + A0=1.19239 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20726
 + ALPHA0=0.00011054914 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.187714
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -21848,8 +21848,8 @@ M0 d1 g s1 b pmos_3p3
 + LUA=6.3109714e-016 LUB1=-1.8188571e-025 LUC=7.0302857e-017 LUC1=-2.16e-017
 + LVTH0=-5.7257143e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.39221571 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466
@@ -22035,7 +22035,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.14 PMOS
+.MODEL pfet_03v3.14 PMOS
 + A0=1.1825286 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16634864
 + ALPHA0=0.002142727 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.230636
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -22057,7 +22057,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=6.8727273e-018 LVOFFCV=-2.1818182e-007 LVTH0=-4.0909091e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15
 + NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20
-+ NOFF=1.9454546 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic}
++ NOFF=1.9454546 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.34150727 PDIBLC1=0.1484 PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
@@ -22244,7 +22244,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.15 PMOS
+.MODEL pfet_03v3.15 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17736
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.599 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4e-011
@@ -22260,8 +22260,8 @@ M0 d1 g s1 b pmos_3p3
 + KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008
 + LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
 + PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466 RDSWMIN=20
@@ -22687,14 +22687,14 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m1
-.ENDL pmos_3p3_t
+.ENDL pfet_03v3_t
 
 
 
 *
 *
-.LIB pmos_3p3_f
-.SUBCKT pmos_3p3_sab d g s b
+.LIB pfet_03v3_f
+.SUBCKT pfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -22718,10 +22718,10 @@ Xr1 d d1 b pplus_u_m1
 
 Xr2 s s1 b pplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_3p3
+M0 d1 g s1 b pfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_3p3.0 PMOS
+.MODEL pfet_03v3.0 PMOS
 + A0=1.0088763 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20174918
 + ALPHA0=1.1235927e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=39.445349
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -22743,7 +22743,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.5583678e-009 LVTH0=-7.3534153e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-2.7146703e-015 PAGS=-1.198112e-014 PALPHA0=6.3405134e-020
 + PARAMCHK=1 PBETA0=1.1730752e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.35995623 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -22768,7 +22768,7 @@ M0 d1 g s1 b pmos_3p3
 + WVTH0=4.7732695e-009 WW=0 WWL=0 WWN=1 XJ=1e-007 XL=-1.2e-008 XPART=0 XTIS=3
 + XW=1e-008
 + LEVEL=14
-.MODEL pmos_3p3.1 PMOS
+.MODEL pfet_03v3.1 PMOS
 + A0=1.1426483 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19126654
 + ALPHA0=7.4423186e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=42.301722
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -22790,7 +22790,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-2.9952355e-017 LVOFF=1.2455386e-008 LVTH0=7.6993553e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.7075901e-014 PAGS=-3.1408371e-014 PALPHA0=-2.4517655e-018
 + PARAMCHK=1 PBETA0=8.7397887e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.25217946 PDIBLC1=0.1484 PDIBLC2=0.00025119377 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -22970,7 +22970,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.2 PMOS
+.MODEL pfet_03v3.2 PMOS
 + A0=1.2624812 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.1574043
 + ALPHA0=0.0020546973 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.410558
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -22993,7 +22993,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFFCV=-2.157408e-007 LVTH0=-9.7863494e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.946
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=3.5872446e-014 PAGS=-1.5607258e-014 PALPHA0=-2.4494972e-017
 + PARAMCHK=1 PBETA0=-7.0826067e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.32107112 PDIBLC1=0.1484 PDIBLC2=7.88813e-005 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -23212,7 +23212,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.3 PMOS
+.MODEL pfet_03v3.3 PMOS
 + A0=1.2226 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17184786
 + ALPHA0=0.0018157893 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.680357
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -23229,7 +23229,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32471786
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -23458,7 +23458,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.4 PMOS
+.MODEL pfet_03v3.4 PMOS
 + A0=0.65645235 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.21104356
 + ALPHA0=1.1826838e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.990543
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -23480,7 +23480,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.2836296e-017 LVTH0=-1.9920781e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-5.3153436e-014 PAGS=5.9902112e-015 PALPHA0=7.1423027e-020
 + PARAMCHK=1 PBETA0=-3.3992511e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.38016331 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -23665,7 +23665,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.5 PMOS
+.MODEL pfet_03v3.5 PMOS
 + A0=1.3375751 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19358686
 + ALPHA0=0.00012216672 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.26392
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -23687,7 +23687,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.790912e-017 LVOFF=1.2455386e-008 LVTH0=-4.0309955e-010 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=7.4052143e-014 PAGS=-1.5240812e-014 PALPHA0=9.7518057e-018
 + PARAMCHK=1 PBETA0=2.5529903e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.55232393 PDIBLC1=0.1484 PDIBLC2=0.00025119377 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -23906,7 +23906,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.6 PMOS
+.MODEL pfet_03v3.6 PMOS
 + A0=1.1176952 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16577511
 + ALPHA0=0.0021717533 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.341063
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -23929,8 +23929,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-4.9350708e-017 LVOFF=-2.0278287e-008 LVOFFCV=-2.157408e-007
 + LVTH0=-1.3585892e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.946 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.946 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-8.6896311e-014 PAGS=4.3699301e-015 PALPHA0=3.1350481e-017 PARAMCHK=1
 + PBETA0=-5.5251989e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32904913
 + PDIBLC1=0.1484 PDIBLC2=7.88813e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
@@ -24146,7 +24146,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.7 PMOS
+.MODEL pfet_03v3.7 PMOS
 + A0=1.1010057 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17644486
 + ALPHA0=0.0019222957 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.701857
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -24163,7 +24163,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -24389,7 +24389,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.8 PMOS
+.MODEL pfet_03v3.8 PMOS
 + A0=0.87540638 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.33412543
 + ALPHA0=9.5254751e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.601303
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -24411,8 +24411,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.2006485e-025 LUC=-6.9634759e-018 LUC1=8.3755803e-019
 + LVTH0=-8.201616e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-1.4501221e-015 PAGS=8.8849145e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-1.4501221e-015 PAGS=8.8849145e-014
 + PALPHA0=-7.8381597e-019 PARAMCHK=1 PBETA0=-7.2672783e-013 PBS=0.69939
 + PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32908612 PDIBLC1=0.1484 PDIBLC2=0.00073695
 + PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PK2=-2.1410135e-015
@@ -24594,7 +24594,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.9 PMOS
+.MODEL pfet_03v3.9 PMOS
 + A0=1.1722707 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20910427
 + ALPHA0=0.00011002657 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.086027
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -24617,7 +24617,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.7409232e-009 LVTH0=-6.9145954e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.0489184e-013 PAGS=3.0536365e-015 PALPHA0=2.9909383e-018
 + PARAMCHK=1 PBETA0=-4.6443141e-015 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37814802 PDIBLC1=0.1484 PDIBLC2=0.00025119377 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -24838,7 +24838,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.10 PMOS
+.MODEL pfet_03v3.10 PMOS
 + A0=1.1829466 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.1669723
 + ALPHA0=0.002140198 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.155152
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -24861,8 +24861,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.3444942e-017 LVOFF=2.8343515e-009 LVOFFCV=-2.157408e-007
 + LVTH0=-4.4220735e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.946 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=7.1057185e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.946 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=7.1057185e-014
 + PAGS=1.7390958e-015 PALPHA0=-3.780643e-018 PARAMCHK=1 PBETA0=-8.2418018e-013
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.34321309 PDIBLC1=0.1484
 + PDIBLC2=7.88813e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0
@@ -25083,7 +25083,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.11 PMOS
+.MODEL pfet_03v3.11 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17785619
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.538059 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=3.6e-011
@@ -25100,7 +25100,7 @@ M0 d1 g s1 b pmos_3p3
 + LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -25327,7 +25327,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.12 PMOS
+.MODEL pfet_03v3.12 PMOS
 + A0=0.86832964 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.31597309
 + ALPHA0=9.7661218e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.749218
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -25348,8 +25348,8 @@ M0 d1 g s1 b pmos_3p3
 + LU0=1.65739e-009 LUA=5.9875293e-016 LUA1=-1.4457577e-016 LUB1=-1.2614711e-025
 + LUC=-5.296752e-018 LVTH0=-7.4903564e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.33743927 PDIBLC1=0.1484
 + PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -25529,7 +25529,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.13 PMOS
+.MODEL pfet_03v3.13 PMOS
 + A0=1.1863276 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.2084804
 + ALPHA0=0.00010949602 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.086417
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -25551,8 +25551,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.7574525e-025 LUC=6.7929433e-017 LUC1=-2.0870784e-017
 + LVTH0=-5.5324142e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.39263726 PDIBLC1=0.1484 PDIBLC2=0.00025119377 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466
@@ -25737,7 +25737,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.14 PMOS
+.MODEL pfet_03v3.14 PMOS
 + A0=1.1822374 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16645875
 + ALPHA0=0.0021402357 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.22432
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -25759,7 +25759,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=6.7958352e-018 LVOFFCV=-2.157408e-007 LVTH0=-4.04514e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.946
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3415892
 + PDIBLC1=0.1484 PDIBLC2=7.88813e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
 + PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0
@@ -25946,7 +25946,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.15 PMOS
+.MODEL pfet_03v3.15 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17736
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.599 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=3.6e-011
@@ -25962,8 +25962,8 @@ M0 d1 g s1 b pmos_3p3
 + KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008
 + LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
 + PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466 RDSWMIN=20
@@ -26390,13 +26390,13 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m1
-.ENDL pmos_3p3_f
+.ENDL pfet_03v3_f
 
 
 *
 *
-.LIB pmos_3p3_s
-.SUBCKT pmos_3p3_sab d g s b
+.LIB pfet_03v3_s
+.SUBCKT pfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -26420,10 +26420,10 @@ Xr1 d d1 b pplus_u_m1
 
 Xr2 s s1 b pplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_3p3
+M0 d1 g s1 b pfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_3p3.0 PMOS
+.MODEL pfet_03v3.0 PMOS
 + A0=1.0456883 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.1800417
 + ALPHA0=1.1734592e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=40.100221
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -26445,7 +26445,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=6.134421e-017 LVOFF=-1.6389133e-009 LVTH0=-8.0025899e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-2.7472452e-015 PAGS=-1.2124889e-014 PALPHA0=6.4165969e-020
 + PARAMCHK=1 PBETA0=1.1871516e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.3525051 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -26470,7 +26470,7 @@ M0 d1 g s1 b pmos_3p3
 + WVTH0=3.8459166e-009 WW=0 WWL=0 WWN=1 XJ=1e-007 XL=1.2e-008 XPART=0 XTIS=3
 + XW=-1e-008
 + LEVEL=14
-.MODEL pmos_3p3.1 PMOS
+.MODEL pfet_03v3.1 PMOS
 + A0=1.1595369 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.18927812
 + ALPHA0=7.659374e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=42.543923
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -26492,7 +26492,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.1520912e-017 LVOFF=1.3331945e-008 LVTH0=8.4932211e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.6180878e-014 PAGS=-2.976212e-014 PALPHA0=-2.3232577e-018
 + PARAMCHK=1 PBETA0=8.2816979e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.26103151 PDIBLC1=0.1484 PDIBLC2=0.00024138051 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -26671,7 +26671,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.2 PMOS
+.MODEL pfet_03v3.2 PMOS
 + A0=1.2627338 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.15723172
 + ALPHA0=0.0020630943 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.489973
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -26694,7 +26694,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFFCV=-2.2062807e-007 LVTH0=-9.3166113e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9449091
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=3.2476679e-014 PAGS=-1.4129839e-014 PALPHA0=-2.2176222e-017
 + PARAMCHK=1 PBETA0=-6.4121511e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.32178284 PDIBLC1=0.1484 PDIBLC2=7.7987791e-005 PDIBLCB=0 PDITS=0
@@ -26913,7 +26913,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.3 PMOS
+.MODEL pfet_03v3.3 PMOS
 + A0=1.2226 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17172643
 + ALPHA0=0.0018189821 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.743929
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -26930,7 +26930,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32671643
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -27159,7 +27159,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.4 PMOS
+.MODEL pfet_03v3.4 PMOS
 + A0=0.68036585 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19813874
 + ALPHA0=1.233251e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.487806
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -27181,7 +27181,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.6378401e-017 LVTH0=-2.2948864e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-5.7518044e-014 PAGS=6.4820876e-015 PALPHA0=7.7287812e-020
 + PARAMCHK=1 PBETA0=-3.6783751e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37605618 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -27366,7 +27366,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.5 PMOS
+.MODEL pfet_03v3.5 PMOS
 + A0=1.3532832 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19095588
 + ALPHA0=0.00012387909 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.468326
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -27388,7 +27388,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.8446114e-017 LVOFF=1.3331945e-008 LVTH0=-2.3922604e-010 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=7.5032345e-014 PAGS=-1.5442549e-014 PALPHA0=9.8808868e-018
 + PARAMCHK=1 PBETA0=2.5867832e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.55256055 PDIBLC1=0.1484 PDIBLC2=0.00024138051 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -27607,7 +27607,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.6 PMOS
+.MODEL pfet_03v3.6 PMOS
 + A0=1.1202818 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16544644
 + ALPHA0=0.0021756117 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.368279
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -27630,8 +27630,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-5.013773e-017 LVOFF=-2.073766e-008 LVOFFCV=-2.2062807e-007
 + LVTH0=-1.3889719e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9449091 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9449091 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-8.4120993e-014 PAGS=4.2303621e-015 PALPHA0=3.0349201e-017 PARAMCHK=1
 + PBETA0=-5.3487336e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32866743
 + PDIBLC1=0.1484 PDIBLC2=7.7987791e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
@@ -27847,7 +27847,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.7 PMOS
+.MODEL pfet_03v3.7 PMOS
 + A0=1.1029829 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17634543
 + ALPHA0=0.0019212129 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.714429
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -27864,7 +27864,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -28090,7 +28090,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.8 PMOS
+.MODEL pfet_03v3.8 PMOS
 + A0=0.90053503 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.33423596
 + ALPHA0=9.9208915e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.010737
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -28112,8 +28112,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.373636e-025 LUC=-7.929225e-018 LUC1=9.418752e-019 LVTH0=-9.3623482e-009
 + LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0
 + MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20
-+ NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-1.6274819e-015 PAGS=9.9716e-014
++ NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-1.6274819e-015 PAGS=9.9716e-014
 + PALPHA0=-8.79682e-019 PARAMCHK=1 PBETA0=-8.156116e-013 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.32055448 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PK2=-2.4028741e-015
@@ -28295,7 +28295,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.9 PMOS
+.MODEL pfet_03v3.9 PMOS
 + A0=1.1841981 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20666573
 + ALPHA0=0.00011213634 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.288609
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -28318,7 +28318,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.8331424e-009 LVTH0=-7.3771601e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.1022787e-013 PAGS=3.2089804e-015 PALPHA0=3.1430926e-018
 + PARAMCHK=1 PBETA0=-4.8805786e-015 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37742149 PDIBLC1=0.1484 PDIBLC2=0.00024138051 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -28539,7 +28539,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.10 PMOS
+.MODEL pfet_03v3.10 PMOS
 + A0=1.1835318 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16674407
 + ALPHA0=0.0021451803 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.168746
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -28562,8 +28562,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.3638952e-017 LVOFF=2.8514282e-009 LVOFFCV=-2.2062807e-007
 + LVTH0=-4.5159809e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9449091 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=7.1342757e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9449091 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=7.1342757e-014
 + PAGS=1.746085e-015 PALPHA0=-3.795837e-018 PARAMCHK=1 PBETA0=-8.2749248e-013
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.34305511 PDIBLC1=0.1484
 + PDIBLC2=7.7987791e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0
@@ -28784,7 +28784,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.11 PMOS
+.MODEL pfet_03v3.11 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17784813
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.53905 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4.4e-011
@@ -28800,8 +28800,8 @@ M0 d1 g s1 b pmos_3p3
 + KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005
 + LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484
 + PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -29028,7 +29028,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.12 PMOS
+.MODEL pfet_03v3.12 PMOS
 + A0=0.89359946 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.31477964
 + ALPHA0=1.0171733e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.169327
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -29049,8 +29049,8 @@ M0 d1 g s1 b pmos_3p3
 + LU0=1.8946234e-009 LUA=6.844565e-016 LUA1=-1.6526988e-016 LUB1=-1.442034e-025
 + LUC=-6.054912e-018 LVTH0=-8.5625018e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32875891 PDIBLC1=0.1484
 + PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -29230,7 +29230,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.13 PMOS
+.MODEL pfet_03v3.13 PMOS
 + A0=1.1984524 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.2060396
 + ALPHA0=0.00011160227 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.289011
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -29252,8 +29252,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.8811348e-025 LUC=7.2710027e-017 LUC1=-2.2339584e-017
 + LVTH0=-5.9217627e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.39179417 PDIBLC1=0.1484 PDIBLC2=0.00024138051 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466
@@ -29438,7 +29438,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.14 PMOS
+.MODEL pfet_03v3.14 PMOS
 + A0=1.1828199 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16623852
 + ALPHA0=0.0021452182 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.236953
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -29460,7 +29460,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFFCV=-2.2062807e-007 LVTH0=-4.1367764e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9449091
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.34142534
 + PDIBLC1=0.1484 PDIBLC2=7.7987791e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
 + PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0
@@ -29647,7 +29647,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.15 PMOS
+.MODEL pfet_03v3.15 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17736
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.599 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4.4e-011
@@ -29663,8 +29663,8 @@ M0 d1 g s1 b pmos_3p3
 + KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008
 + LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
 + PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466 RDSWMIN=20
@@ -30090,13 +30090,13 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m1
-.ENDL pmos_3p3_s
+.ENDL pfet_03v3_s
 
 
 *
 *
-.LIB pmos_3p3_fs
-.SUBCKT pmos_3p3_sab d g s b
+.LIB pfet_03v3_fs
+.SUBCKT pfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -30120,10 +30120,10 @@ Xr1 d d1 b pplus_u_m1
 
 Xr2 s s1 b pplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_3p3
+M0 d1 g s1 b pfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_3p3.0 PMOS
+.MODEL pfet_03v3.0 PMOS
 + A0=1.039392 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.18391438
 + ALPHA0=1.1653153e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=39.988812
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -30145,7 +30145,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.6386998e-009 LVTH0=-7.9299856e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-2.7738176e-015 PAGS=-1.2242165e-014 PALPHA0=6.4786605e-020
 + PARAMCHK=1 PBETA0=1.1986341e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.35338606 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -30170,7 +30170,7 @@ M0 d1 g s1 b pmos_3p3
 + WVOFF=-1.6612803e-009 WVTH0=4.0333546e-009 WW=0 WWL=0 WWN=1 XJ=1e-007 XL=8e-009
 + XPART=0 XTIS=3 XW=-5e-009
 + LEVEL=14
-.MODEL pmos_3p3.1 PMOS
+.MODEL pfet_03v3.1 PMOS
 + A0=1.1561845 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.1893918
 + ALPHA0=7.6165264e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=42.499959
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -30192,7 +30192,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.1304785e-017 LVOFF=1.3184133e-008 LVTH0=8.3367507e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.6509626e-014 PAGS=-3.0366798e-014 PALPHA0=-2.3704594e-018
 + PARAMCHK=1 PBETA0=8.4499576e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.25839327 PDIBLC1=0.1484 PDIBLC2=0.00024301606 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -30371,7 +30371,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.2 PMOS
+.MODEL pfet_03v3.2 PMOS
 + A0=1.2627392 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.15724995
 + ALPHA0=0.0020613963 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.471345
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -30394,7 +30394,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFFCV=-2.1981207e-007 LVTH0=-9.4543724e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9450909
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=3.3384084e-014 PAGS=-1.452463e-014 PALPHA0=-2.279583e-017
 + PARAMCHK=1 PBETA0=-6.5913079e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.32160177 PDIBLC1=0.1484 PDIBLC2=7.8136709e-005 PDIBLCB=0 PDITS=0
@@ -30613,7 +30613,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.3 PMOS
+.MODEL pfet_03v3.3 PMOS
 + A0=1.2226 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17175679
 + ALPHA0=0.0018181839 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.728036
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -30630,7 +30630,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32621679
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -30859,7 +30859,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.4 PMOS
+.MODEL pfet_03v3.4 PMOS
 + A0=0.67581086 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.200375
 + ALPHA0=1.2249381e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.401961
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -30881,7 +30881,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC=1.2960088e-017 LUC1=-3.5883051e-017 LVTH0=-2.2414438e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-5.7073625e-014 PAGS=6.4320031e-015 PALPHA0=7.669064e-020
 + PARAMCHK=1 PBETA0=-3.6499537e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37672 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -31066,7 +31066,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.5 PMOS
+.MODEL pfet_03v3.5 PMOS
 + A0=1.3508441 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19135754
 + ALPHA0=0.00012364806 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.434876
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -31088,7 +31088,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.842044e-017 LVOFF=1.3184133e-008 LVTH0=-2.8410138e-010 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=7.5237532e-014 PAGS=-1.5484779e-014 PALPHA0=9.9079077e-018
 + PARAMCHK=1 PBETA0=2.5938572e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.55271631 PDIBLC1=0.1484 PDIBLC2=0.00024301606 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -31307,7 +31307,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.6 PMOS
+.MODEL pfet_03v3.6 PMOS
 + A0=1.1196626 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16551068
 + ALPHA0=0.0021750673 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.362547
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -31330,8 +31330,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-5.0034723e-017 LVOFF=-2.0660961e-008 LVOFFCV=-2.1981207e-007
 + LVTH0=-1.3839329e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9450909 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9450909 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-8.4981251e-014 PAGS=4.2736236e-015 PALPHA0=3.0659565e-017 PARAMCHK=1
 + PBETA0=-5.4034322e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.328728
 + PDIBLC1=0.1484 PDIBLC2=7.8136709e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
@@ -31547,7 +31547,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.7 PMOS
+.MODEL pfet_03v3.7 PMOS
 + A0=1.1024886 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17637029
 + ALPHA0=0.0019214836 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.711286
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -31564,7 +31564,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -31790,7 +31790,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.8 PMOS
+.MODEL pfet_03v3.8 PMOS
 + A0=0.89635642 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.33424764
 + ALPHA0=9.8546141e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.942253
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -31812,8 +31812,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.3439579e-025 LUC=-7.7670863e-018 LUC1=9.2552394e-019
 + LVTH0=-9.1651899e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-1.6000271e-015 PAGS=9.8033842e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-1.6000271e-015 PAGS=9.8033842e-014
 + PALPHA0=-8.6484221e-019 PARAMCHK=1 PBETA0=-8.0185264e-013 PBS=0.69939
 + PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32196515 PDIBLC1=0.1484 PDIBLC2=0.00073695
 + PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PK2=-2.3623388e-015
@@ -31995,7 +31995,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.9 PMOS
+.MODEL pfet_03v3.9 PMOS
 + A0=1.1821897 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20707304
 + ALPHA0=0.00011178547 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.254845
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -32018,7 +32018,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.8203092e-009 LVTH0=-7.3013165e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.0951088e-013 PAGS=3.1881072e-015 PALPHA0=3.122648e-018
 + PARAMCHK=1 PBETA0=-4.8488322e-015 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37752254 PDIBLC1=0.1484 PDIBLC2=0.00024301606 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -32239,7 +32239,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.10 PMOS
+.MODEL pfet_03v3.10 PMOS
 + A0=1.1834353 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16678281
 + ALPHA0=0.0021443499 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.166386
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -32262,8 +32262,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.3616046e-017 LVOFF=2.8526213e-009 LVOFFCV=-2.1981207e-007
 + LVTH0=-4.5008395e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9450909 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=7.1408259e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9450909 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=7.1408259e-014
 + PAGS=1.7476882e-015 PALPHA0=-3.7993221e-018 PARAMCHK=1 PBETA0=-8.2825222e-013
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.34308375 PDIBLC1=0.1484
 + PDIBLC2=7.8136709e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0
@@ -32484,7 +32484,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.11 PMOS
+.MODEL pfet_03v3.11 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17785014
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.538802 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4.2e-011
@@ -32501,7 +32501,7 @@ M0 d1 g s1 b pmos_3p3
 + LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -32728,7 +32728,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.12 PMOS
+.MODEL pfet_03v3.12 PMOS
 + A0=0.88938782 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.31497855
 + ALPHA0=1.0104131e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.099309
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -32749,8 +32749,8 @@ M0 d1 g s1 b pmos_3p3
 + LU0=1.8540707e-009 LUA=6.6980631e-016 LUA1=-1.6173242e-016 LUB1=-1.4111686e-025
 + LUC=-5.925312e-018 LVTH0=-8.3792291e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.33020564 PDIBLC1=0.1484
 + PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -32930,7 +32930,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.13 PMOS
+.MODEL pfet_03v3.13 PMOS
 + A0=1.1964316 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.2064464
 + ALPHA0=0.00011125123 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.255246
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -32952,8 +32952,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.8602786e-025 LUC=7.1903887e-017 LUC1=-2.2091904e-017
 + LVTH0=-5.8561079e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.39193469 PDIBLC1=0.1484 PDIBLC2=0.00024301606 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466
@@ -33138,7 +33138,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.14 PMOS
+.MODEL pfet_03v3.14 PMOS
 + A0=1.1827228 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16627523
 + ALPHA0=0.0021443878 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.234847
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -33160,7 +33160,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=6.9240803e-018 LVOFFCV=-2.1981207e-007 LVTH0=-4.1214764e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15
 + NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20
-+ NOFF=1.9450909 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic}
++ NOFF=1.9450909 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.34145265 PDIBLC1=0.1484 PDIBLC2=7.8136709e-005 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
@@ -33347,7 +33347,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.15 PMOS
+.MODEL pfet_03v3.15 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17736
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.599 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4.2e-011
@@ -33363,8 +33363,8 @@ M0 d1 g s1 b pmos_3p3
 + KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008
 + LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
 + PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466 RDSWMIN=20
@@ -33791,11 +33791,11 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m1
-.ENDL pmos_3p3_fs
+.ENDL pfet_03v3_fs
 *
 *
-.LIB pmos_3p3_sf
-.SUBCKT pmos_3p3_sab d g s b
+.LIB pfet_03v3_sf
+.SUBCKT pfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -33818,10 +33818,10 @@ Xr1 d d1 b pplus_u_m1
 
 Xr2 s s1 b pplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_3p3
+M0 d1 g s1 b pfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_3p3.0 PMOS
+.MODEL pfet_03v3.0 PMOS
 + A0=1.0151475 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19776586
 + ALPHA0=1.1317951e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=39.557841
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -33843,7 +33843,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=5.6525433e-017 LVOFF=-1.5626994e-009 LVTH0=-7.4340753e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15
 + NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20
-+ NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic}
++ NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PA0=-2.6965346e-015 PAGS=-1.1901079e-014
 + PALPHA0=6.2981547e-020 PARAMCHK=1 PBETA0=1.1652383e-013 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.35913516 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0
@@ -33868,7 +33868,7 @@ M0 d1 g s1 b pmos_3p3
 + WUC1=4.1267577e-017 WVOFF=-1.6675146e-009 WVTH0=4.5642665e-009 WW=0 WWL=0 WWN=1
 + XJ=1e-007 XL=-8e-009 XPART=0 XTIS=3 XW=5e-009
 + LEVEL=14
-.MODEL pmos_3p3.1 PMOS
+.MODEL pfet_03v3.1 PMOS
 + A0=1.1459651 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19108744
 + ALPHA0=7.4846555e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=42.345869
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -33890,7 +33890,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.0172107e-017 LVOFF=1.259976e-008 LVTH0=7.848145e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.6768655e-014 PAGS=-3.0843241e-014 PALPHA0=-2.407651e-018
 + PARAMCHK=1 PBETA0=8.5825341e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.25477175 PDIBLC1=0.1484 PDIBLC2=0.00024955823 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -34069,7 +34069,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.2 PMOS
+.MODEL pfet_03v3.2 PMOS
 + A0=1.2624795 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.15738448
 + ALPHA0=0.0020563928 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.429178
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -34092,7 +34092,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFFCV=-2.1655389e-007 LVTH0=-9.6535664e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9458182
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=3.495459e-014 PAGS=-1.520792e-014 PALPHA0=-2.3868227e-017
 + PARAMCHK=1 PBETA0=-6.9013864e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.32126019 PDIBLC1=0.1484 PDIBLC2=7.8732382e-005 PDIBLCB=0 PDITS=0
@@ -34311,7 +34311,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.3 PMOS
+.MODEL pfet_03v3.3 PMOS
 + A0=1.2226 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.1718175
 + ALPHA0=0.0018165875 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.69625
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -34328,7 +34328,7 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3252175
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -34557,7 +34557,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.4 PMOS
+.MODEL pfet_03v3.4 PMOS
 + A0=0.66090759 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20881855
 + ALPHA0=1.1910101e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.07575
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -34579,7 +34579,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.3340425e-017 LVTH0=-2.0423367e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-5.3656847e-014 PAGS=6.0469439e-015 PALPHA0=7.2099467e-020
 + PARAMCHK=1 PBETA0=-3.4314451e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37955209 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -34764,7 +34764,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.5 PMOS
+.MODEL pfet_03v3.5 PMOS
 + A0=1.3400455 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19317874
 + ALPHA0=0.00012240188 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.297479
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -34786,7 +34786,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.7945798e-017 LVOFF=1.259976e-008 LVTH0=-3.6235097e-010 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=7.3902161e-014 PAGS=-1.5209944e-014 PALPHA0=9.7320549e-018
 + PARAMCHK=1 PBETA0=2.5478195e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.5521986 PDIBLC1=0.1484 PDIBLC2=0.00024955823 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -35005,7 +35005,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.6 PMOS
+.MODEL pfet_03v3.6 PMOS
 + A0=1.1183126 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16571096
 + ALPHA0=0.0021722983 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.346784
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -35028,8 +35028,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-4.9455495e-017 LVOFF=-2.0354712e-008 LVOFFCV=-2.1655389e-007
 + LVTH0=-1.3636128e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9458182 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9458182 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-8.6049719e-014 PAGS=4.3273558e-015 PALPHA0=3.1045047e-017 PARAMCHK=1
 + PBETA0=-5.4713694e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32898832
 + PDIBLC1=0.1484 PDIBLC2=7.8732382e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
@@ -35245,7 +35245,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.7 PMOS
+.MODEL pfet_03v3.7 PMOS
 + A0=1.1015 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17642
 + ALPHA0=0.001922025 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.705 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=3.8e-011
@@ -35261,8 +35261,8 @@ M0 d1 g s1 b pmos_3p3
 + KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005
 + LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484
 + PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -35488,7 +35488,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.8 PMOS
+.MODEL pfet_03v3.8 PMOS
 + A0=0.87958485 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.33412256
 + ALPHA0=9.5916748e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.669715
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -35510,8 +35510,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.2288098e-025 LUC=-7.1184051e-018 LUC1=8.5354274e-019
 + LVTH0=-8.3892994e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-1.4770608e-015 PAGS=9.0499685e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-1.4770608e-015 PAGS=9.0499685e-014
 + PALPHA0=-7.9837683e-019 PARAMCHK=1 PBETA0=-7.4022817e-013 PBS=0.69939
 + PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32767553 PDIBLC1=0.1484 PDIBLC2=0.00073695
 + PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PK2=-2.1807869e-015
@@ -35693,7 +35693,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.9 PMOS
+.MODEL pfet_03v3.9 PMOS
 + A0=1.1742768 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20869703
 + ALPHA0=0.00011037751 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.119792
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -35716,7 +35716,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.7539439e-009 LVTH0=-6.989061e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.0562366e-013 PAGS=3.0749415e-015 PALPHA0=3.0118059e-018
 + PARAMCHK=1 PBETA0=-4.6767172e-015 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37804632 PDIBLC1=0.1484 PDIBLC2=0.00024955823 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -35937,7 +35937,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.10 PMOS
+.MODEL pfet_03v3.10 PMOS
 + A0=1.1830432 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16693357
 + ALPHA0=0.0021410284 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.157511
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -35960,8 +35960,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.3468483e-017 LVOFF=2.8334685e-009 LVOFFCV=-2.1655389e-007
 + LVTH0=-4.4372015e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9458182 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=7.0999638e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9458182 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=7.0999638e-014
 + PAGS=1.7376873e-015 PALPHA0=-3.7775811e-018 PARAMCHK=1 PBETA0=-8.2351269e-013
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.34318463 PDIBLC1=0.1484
 + PDIBLC2=7.8732382e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0
@@ -36182,7 +36182,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.11 PMOS
+.MODEL pfet_03v3.11 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17785418
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.538307 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=3.8e-011
@@ -36199,7 +36199,7 @@ M0 d1 g s1 b pmos_3p3
 + LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
@@ -36426,7 +36426,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.12 PMOS
+.MODEL pfet_03v3.12 PMOS
 + A0=0.87254127 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.31577418
 + ALPHA0=9.8337236e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.819236
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -36447,8 +36447,8 @@ M0 d1 g s1 b pmos_3p3
 + LU0=1.695915e-009 LUA=6.126706e-016 LUA1=-1.4793635e-016 LUB1=-1.2907933e-025
 + LUC=-5.419872e-018 LVTH0=-7.6644654e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.33599254 PDIBLC1=0.1484
 + PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
@@ -36628,7 +36628,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.13 PMOS
+.MODEL pfet_03v3.13 PMOS
 + A0=1.1883484 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.2080736
 + ALPHA0=0.00010984706 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.120183
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -36650,8 +36650,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.7778237e-025 LUC=6.8716825e-017 LUC1=-2.1112704e-017
 + LVTH0=-5.5965422e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.39249674 PDIBLC1=0.1484 PDIBLC2=0.00024955823 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466
@@ -36836,7 +36836,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.14 PMOS
+.MODEL pfet_03v3.14 PMOS
 + A0=1.1823344 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16642204
 + ALPHA0=0.0021410661 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.226425
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -36858,7 +36858,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=6.8214476e-018 LVOFFCV=-2.1655389e-007 LVTH0=-4.0603855e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15
 + NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20
-+ NOFF=1.9458182 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic}
++ NOFF=1.9458182 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.34156189 PDIBLC1=0.1484 PDIBLC2=7.8732382e-005 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
@@ -37045,7 +37045,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.15 PMOS
+.MODEL pfet_03v3.15 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17736
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.599 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=3.8e-011
@@ -37061,8 +37061,8 @@ M0 d1 g s1 b pmos_3p3
 + KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008
 + LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
 + PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW=466 RDSWMIN=20
@@ -37489,7 +37489,7 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m1
-.ENDL pmos_3p3_sf
+.ENDL pfet_03v3_sf
 
 
 *
@@ -37498,8 +37498,8 @@ Rb 1 2
 * 6V NMOS Models
 ***************************************************************************************************
 *
-.LIB nmos_6p0_t
-.SUBCKT nmos_6p0_sab d g s b
+.LIB nfet_06v0_t
+.SUBCKT nfet_06v0_dss d g s b
 + PARAMS: W=10u L=0.6u PAR=1 S_SAB=0.28u D_SAB=3.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -37523,16 +37523,16 @@ Xr1 d d1 b nplus_u_m2
 
 Xr2 s s1 b nplus_u_m2
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b nmos_6p0
+M0 d1 g s1 b nfet_06v0
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL nmos_6p0.0 NMOS
+.MODEL nfet_06v0.0 NMOS
 + A0=0.72499969 A1=0 A2=0.96 ACDE=0.3 ACNQSMOD=0 AGIDL=0 AGS=0.13699995
 + AIGBACC=0.43 AIGBINV=0.35 AIGC=0.43 AIGSD=0.43 ALPHA0=-1.88e-007 ALPHA1=19
 + AT=109000.03 B0=0 B1=0 BETA0=36.6 BGIDL=2.3e+009 BIGBACC=0.054 BIGBINV=0.03
 + BIGC=0.054 BIGSD=0.054 BINUNIT=1 BVS=11 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0
-+ CGBO=1e-013 CGDL='1.5e-010*nmos_6p0_cgdo' CGDO='1e-010*nmos_6p0_cgdo' CGIDL=0.5
-+ CGSL='1.5e-010*nmos_6p0_cgso' CGSO='1e-010*nmos_6p0_cgso' CIGBACC=0.075
++ CGBO=1e-013 CGDL='1.5e-010*nfet_06v0_cgdo' CGDO='1e-010*nfet_06v0_cgdo' CGIDL=0.5
++ CGSL='1.5e-010*nfet_06v0_cgso' CGSO='1e-010*nfet_06v0_cgso' CIGBACC=0.075
 + CIGBINV=0.006 CIGC=0.075 CIGSD=0.075 CIT=0 CJS=0.00095 CJSWGS=3.573e-010
 + CJSWS=1.33e-010 CKAPPAD=0.6 CKAPPAS=0.6 CLC=1e-010 CLE=0.6 DELTA=0.01 DIOMOD=1
 + DLC=5.4E-8 DLCIG=0 DMCG=0 DMCGT=0 DMDG=0 DROUT=0.4 DSUB=0.4 DVT0=5.72 DVT0W=10
@@ -37547,17 +37547,17 @@ M0 d1 g s1 b nmos_6p0
 + LL=1.93e-014 LLC=0 LLN=1 LLODKU0=0 LLODVTH=0 LMAX=5.0001e-005 LMIN=7e-007
 + LODETA0=1 LODK2=1 LP=1e-008 LPCLM=0.89088024 LPE0=1.63e-007 LPEB=0
 + LU0=0.019999998 LUA=-3.3696895e-019 LUB=1.7400001e-018 LUC=9.8000018e-011
-+ LUC1=-1.8816003e-011 LUTE=0.030000222 LVSAT='-2649.9871*nmos_6p0_vsat' LW=0
++ LUC1=-1.8816003e-011 LUTE=0.030000222 LVSAT='-2649.9871*nfet_06v0_vsat' LW=0
 + LWC=0 LWL=0 LWLC=0 LWN=1 MINV=0 MJS=0.296 MJSWGS=0.40313 MJSWS=0.01 MOBMOD=0
 + MOIN=15 NDEP=1.7e+017 NFACTOR=0.864 NGATE=1e+020 NGCON=1 NIGBACC=1 NIGBINV=3
-+ NIGC=1 NJS=1.0541 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.5 NOIA='nmos_6p0_noia'
-+ NOIB='nmos_6p0_noib' NOIC='nmos_6p0_noic' NSD=1e+020 NTNOI=1 NTOX=1
++ NIGC=1 NJS=1.0541 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.5 NOIA='nfet_06v0_noia'
++ NOIB='nfet_06v0_noib' NOIC='nfet_06v0_noic' NSD=1e+020 NTNOI=1 NTOX=1
 + PAGS=0.0070910278 PARAMCHK=1 PAT=-6699.9857 PBS=0.606 PBSWGS=0.861 PBSWS=0.48
 + PCLM=0.0099999763 PDIBLC1=1.6 PDIBLC2=0.0022 PDIBLCB=0 PDITS=0 PDITSD=0
 + PDITSL=0 PERMOD=1 PHIN=0 PIGCD=1 PKU0=0 PKVTH0=0 POXEDGE=1 PRT=0 PRWB=0 PRWG=1
 + PSCBE1=4.325e+009 PSCBE2=8.8e-006 PU0=0.0018000065 PUA=1.4622721e-010
 + PUB=-2.3803999e-019 PUC=-5.6168065e-012 PUTE=-0.019999981 PVAG=1.75
-+ PVSAT='6308.7992*nmos_6p0_vsat' RBDB=50 RBDBX0=100 RBDBY0=100 RBODYMOD=0
++ PVSAT='6308.7992*nfet_06v0_vsat' RBDB=50 RBDBX0=100 RBDBY0=100 RBODYMOD=0
 + RBPB=50 RBPBX0=100 RBPBXL=0 RBPBXNF=0 RBPBXW=0 RBPBY0=100 RBPBYL=0 RBPBYNF=0
 + RBPBYW=0 RBPD=50 RBPD0=50 RBPDL=0 RBPDNF=0 RBPDW=0 RBPS=50 RBPS0=50 RBPSL=0
 + RBPSNF=0 RBPSW=0 RBSB=50 RBSBX0=100 RBSBY0=100 RBSDBXL=0 RBSDBXNF=0 RBSDBXW=0
@@ -37565,29 +37565,29 @@ M0 d1 g s1 b nmos_6p0
 + RGATEMOD=0 RSH=7 RSHG=0.1 RSW=100 RSWMIN=0 SAREF=1e-006 SBREF=1e-006
 + SCREF=1e-006 STETA0=0 STK2=0 TCJ=0.000825 TCJSW=0.0018 TCJSWG=0.001595
 + TEMPMOD=0 TKU0=0 TNJTS=0 TNJTSSW=0 TNJTSSWG=0 TNOIMOD=0 TNOM=25
-+ TOXE='1.52e-008+nmos_6p0_tox' TOXM='1.52e-008+nmos_6p0_tox'
-+ TOXP='1.6e-008+nmos_6p0_tox' TOXREF=1.52e-008 TPB=0.00146 TPBSW=0.00313
++ TOXE='1.52e-008+nfet_06v0_tox' TOXM='1.52e-008+nfet_06v0_tox'
++ TOXP='1.6e-008+nfet_06v0_tox' TOXREF=1.52e-008 TPB=0.00146 TPBSW=0.00313
 + TPBSWG=0.0016588 TRNQSMOD=0 TVFBSDOFF=0 TVOFF=0 U0=0.052500014
 + UA=6.8000001e-012 UA1=1e-009 UB=2.8799997e-018 UB1=-1e-018 UC=7.9399996e-011
 + UC1=-5.5999995e-011 UD1=0 UP=0 UTE=-1.5000005 VBM=-3 VFBCV=-1 VFBSDOFF=0
-+ VOFF=-0.08 VOFFCV=0 VOFFL=0 VSAT='103999.98*nmos_6p0_vsat'
-+ VTH0='0.67314+nmos_6p0_vth0' VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
++ VOFF=-0.08 VOFFCV=0 VOFFL=0 VSAT='103999.98*nfet_06v0_vsat'
++ VTH0='0.67314+nfet_06v0_vth0' VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
 + VTSSWGS=10 VTSSWS=10 W0=1e-009 WAGS=-4.2211594e-008 WAT=6479.9797 WEB=0 WEC=0
 + WINT=1.55e-008 WK3=-0.047531062 WKU0=0 WKVTH0=0 WL=0 WLC=0 WLN=1 WLOD=0
 + WLODKU0=0 WLODVTH=0 WMAX=0.000100001 WMIN=3e-007 WPEMOD=0 WR=1
 + WU0=-8.0300635e-009 WUA=-8.4912706e-019 WUB=-1.1655759e-026 WUC=8.0000028e-012
-+ WUTE=0.06000001 WVSAT='0.012447116*nmos_6p0_vsat' WW=-2.7e-015 WWC=0 WWL=0
-+ WWLC=0 WWN=1 XGL=0 XGW=0 XJ=1.5e-007 XJBVD=1 XJBVS=1 XL='0+nmos_6p0_xl' XN=3
++ WUTE=0.06000001 WVSAT='0.012447116*nfet_06v0_vsat' WW=-2.7e-015 WWC=0 WWL=0
++ WWLC=0 WWN=1 XGL=0 XGW=0 XJ=1.5e-007 XJBVD=1 XJBVS=1 XL='0+nfet_06v0_xl' XN=3
 + XPART=0 XRCRG1=12 XRCRG2=1 XTIS=3 XTSD=0.02 XTSS=0.02 XTSSWD=0.02 XTSSWGD=0.02
-+ XTSSWGS=0.02 XTSSWS=0.02 XW='0+nmos_6p0_xw'
++ XTSSWGS=0.02 XTSSWS=0.02 XW='0+nfet_06v0_xw'
 + LEVEL=14
-.MODEL nmos_6p0.1 NMOS
+.MODEL nfet_06v0.1 NMOS
 + A0=0.72500081 A1=0 A2=0.96 ACDE=0.3 ACNQSMOD=0 AGIDL=0 AGS=0.13700019
 + AIGBACC=0.43 AIGBINV=0.35 AIGC=0.43 AIGSD=0.43 ALPHA0=-1.88e-007 ALPHA1=19
 + AT=-119957.68 B0=0 B1=0 BETA0=36.6 BGIDL=2.3e+009 BIGBACC=0.054 BIGBINV=0.03
 + BIGC=0.054 BIGSD=0.054 BINUNIT=1 BVS=11 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0
-+ CGBO=1e-013 CGDL='1.5e-010*nmos_6p0_cgdo' CGDO='1e-010*nmos_6p0_cgdo' CGIDL=0.5
-+ CGSL='1.5e-010*nmos_6p0_cgso' CGSO='1e-010*nmos_6p0_cgso' CIGBACC=0.075
++ CGBO=1e-013 CGDL='1.5e-010*nfet_06v0_cgdo' CGDO='1e-010*nfet_06v0_cgdo' CGIDL=0.5
++ CGSL='1.5e-010*nfet_06v0_cgso' CGSO='1e-010*nfet_06v0_cgso' CIGBACC=0.075
 + CIGBINV=0.006 CIGC=0.075 CIGSD=0.075 CIT=0 CJS=0.00095 CJSWGS=3.573e-010
 + CJSWS=1.33e-010 CKAPPAD=0.6 CKAPPAS=0.6 CLC=1e-010 CLE=0.6 DELTA=0.01 DIOMOD=1
 + DLC=5.4E-8 DLCIG=0 DMCG=0 DMCGT=0 DMDG=0 DROUT=0.4 DSUB=0.4 DVT0=5.72 DVT0W=10
@@ -37602,16 +37602,16 @@ M0 d1 g s1 b nmos_6p0
 + LL=1.93e-014 LLC=0 LLN=1 LLODKU0=0 LLODVTH=0 LMAX=7e-007 LMIN=6e-007 LODETA0=1
 + LODK2=1 LP=1e-008 LPCLM=0.89088046 LPE0=1.63e-007 LPEB=0 LU0=0.019999754
 + LUA=3.7339196e-019 LUB=1.7399991e-018 LUC=9.7999741e-011 LUC1=-1.8816017e-011
-+ LUTE=0.030000412 LVSAT='24946.5*nmos_6p0_vsat' LW=0 LWC=0 LWL=0 LWLC=0 LWN=1
++ LUTE=0.030000412 LVSAT='24946.5*nfet_06v0_vsat' LW=0 LWC=0 LWL=0 LWLC=0 LWN=1
 + MINV=0 MJS=0.296 MJSWGS=0.40313 MJSWS=0.01 MOBMOD=0 MOIN=15 NDEP=1.7e+017
 + NFACTOR=0.864 NGATE=1e+020 NGCON=1 NIGBACC=1 NIGBINV=3 NIGC=1 NJS=1.0541
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.5 NOIA='nmos_6p0_noia' NOIB='nmos_6p0_noib'
-+ NOIC='nmos_6p0_noic' NSD=1e+020 NTNOI=1 NTOX=1 PAGS=0.0070909573 PARAMCHK=1
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.5 NOIA='nfet_06v0_noia' NOIB='nfet_06v0_noib'
++ NOIC='nfet_06v0_noic' NSD=1e+020 NTNOI=1 NTOX=1 PAGS=0.0070909573 PARAMCHK=1
 + PAT=21832.424 PBS=0.606 PBSWGS=0.861 PBSWS=0.48 PCLM=0.0099996572 PDIBLC1=1.6
 + PDIBLC2=0.0022 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PIGCD=1
 + PKU0=0 PKVTH0=0 POXEDGE=1 PRT=0 PRWB=0 PRWG=1 PSCBE1=4.325e+009 PSCBE2=8.8e-006
 + PU0=0.0018000207 PUA=1.4622711e-010 PUB=-2.3804013e-019 PUC=-5.6167642e-012
-+ PUTE=-0.020000108 PVAG=1.75 PVSAT='6308.7053*nmos_6p0_vsat' RBDB=50 RBDBX0=100
++ PUTE=-0.020000108 PVAG=1.75 PVSAT='6308.7053*nfet_06v0_vsat' RBDB=50 RBDBX0=100
 + RBDBY0=100 RBODYMOD=0 RBPB=50 RBPBX0=100 RBPBXL=0 RBPBXNF=0 RBPBXW=0 RBPBY0=100
 + RBPBYL=0 RBPBYNF=0 RBPBYW=0 RBPD=50 RBPD0=50 RBPDL=0 RBPDNF=0 RBPDW=0 RBPS=50
 + RBPS0=50 RBPSL=0 RBPSNF=0 RBPSW=0 RBSB=50 RBSBX0=100 RBSBY0=100 RBSDBXL=0
@@ -37619,21 +37619,21 @@ M0 d1 g s1 b nmos_6p0
 + RDSWMIN=0 RDW=100 RDWMIN=0 RGATEMOD=0 RSH=7 RSHG=0.1 RSW=100 RSWMIN=0
 + SAREF=1e-006 SBREF=1e-006 SCREF=1e-006 STETA0=0 STK2=0 TCJ=0.000825
 + TCJSW=0.0018 TCJSWG=0.001595 TEMPMOD=0 TKU0=0 TNJTS=0 TNJTSSW=0 TNJTSSWG=0
-+ TNOIMOD=0 TNOM=25 TOXE='1.52e-008+nmos_6p0_tox' TOXM='1.52e-008+nmos_6p0_tox'
-+ TOXP='1.6e-008+nmos_6p0_tox' TOXREF=1.52e-008 TPB=0.00146 TPBSW=0.00313
++ TNOIMOD=0 TNOM=25 TOXE='1.52e-008+nfet_06v0_tox' TOXM='1.52e-008+nfet_06v0_tox'
++ TOXP='1.6e-008+nfet_06v0_tox' TOXREF=1.52e-008 TPB=0.00146 TPBSW=0.00313
 + TPBSWG=0.0016588 TRNQSMOD=0 TVFBSDOFF=0 TVOFF=0 U0=0.052500361
 + UA=6.7999991e-012 UA1=1e-009 UB=2.8800011e-018 UB1=-1e-018 UC=7.9400388e-011
 + UC1=-5.5999975e-011 UD1=0 UP=0 UTE=-1.5000008 VBM=-3 VFBCV=-1 VFBSDOFF=0
-+ VOFF=-0.08 VOFFCV=0 VOFFL=0 VSAT='64848.09*nmos_6p0_vsat'
-+ VTH0='0.67314+nmos_6p0_vth0' VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
++ VOFF=-0.08 VOFFCV=0 VOFFL=0 VSAT='64848.09*nfet_06v0_vsat'
++ VTH0='0.67314+nfet_06v0_vth0' VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
 + VTSSWGS=10 VTSSWS=10 W0=1e-009 WAGS=5.7853969e-008 WAT=-33999.727 WEB=0 WEC=0
 + WINT=1.55e-008 WK3=-0.047531062 WKU0=0 WKVTH0=0 WL=0 WLC=0 WLN=1 WLOD=0
 + WLODKU0=0 WLODVTH=0 WMAX=0.000100001 WMIN=3e-007 WPEMOD=0 WR=1
 + WU0=-2.8167565e-008 WUA=1.3244868e-016 WUB=1.8765824e-025 WUC=7.9999428e-012
-+ WUTE=0.060000189 WVSAT='0.14568305*nmos_6p0_vsat' WW=-2.7e-015 WWC=0 WWL=0
-+ WWLC=0 WWN=1 XGL=0 XGW=0 XJ=1.5e-007 XJBVD=1 XJBVS=1 XL='0+nmos_6p0_xl' XN=3
++ WUTE=0.060000189 WVSAT='0.14568305*nfet_06v0_vsat' WW=-2.7e-015 WWC=0 WWL=0
++ WWLC=0 WWN=1 XGL=0 XGW=0 XJ=1.5e-007 XJBVD=1 XJBVS=1 XL='0+nfet_06v0_xl' XN=3
 + XPART=0 XRCRG1=12 XRCRG2=1 XTIS=3 XTSD=0.02 XTSS=0.02 XTSSWD=0.02 XTSSWGD=0.02
-+ XTSSWGS=0.02 XTSSWS=0.02 XW='0+nmos_6p0_xw'
++ XTSSWGS=0.02 XTSSWS=0.02 XW='0+nfet_06v0_xw'
 + LEVEL=14
 *resistor
 
@@ -37754,27 +37754,27 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS nplus_u_m2
-.ENDL nmos_6p0_t
+.ENDL nfet_06v0_t
 
 *
 ***************************************************************************************************
 * 6V native NMOS Models
 ***************************************************************************************************
 *
-.LIB nmos_6p0_nat_t
-.SUBCKT nmos_6p0_nat d g s b
+.LIB nfet_06v0_nvt_t
+.SUBCKT nfet_06v0_nvt d g s b
 + PARAMS: W=1e-5 L=1.8e-6 AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0 PAR=1 DTEMP=0 SA=0 SB=0 NF=1
 + SD=0 M=1
-M0 d g s b nmos_6p0_nat
+M0 d g s b nfet_06v0_nvt
 + AD={ad} AS={as} L={l} NRD={nrd} NRS={nrs} PD={pd} PS={ps} W={w}
-.ENDS nmos_6p0_nat
-.MODEL nmos_6p0_nat.0 NMOS
+.ENDS nfet_06v0_nvt
+.MODEL nfet_06v0_nvt.0 NMOS
 + A0=0.88 A1=0 A2=0.47 ACDE=0.3 ACNQSMOD=0 AGIDL=2e-010 AGS=0.72 AIGBACC=0.43
 + AIGBINV=0.35 AIGC=0.43 AIGSD=0.43 ALPHA0=1.36e-008 ALPHA1=1e-005 AT=80000
 + B0=3.5e-007 B1=0 BETA0=15 BGIDL=2.3e+009 BIGBACC=0.054 BIGBINV=0.03 BIGC=0.054
 + BIGSD=0.054 BINUNIT=1 BVS=11 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CGBO=1e-013
-+ CGDL=1.5e-010 CGDO={nmos_6p0_nat_cgdo} CGIDL=0.5 CGSL=1.5e-010
-+ CGSO={nmos_6p0_nat_cgso} CIGBACC=0.075 CIGBINV=0.006 CIGC=0.075 CIGSD=0.075
++ CGDL=1.5e-010 CGDO={nfet_06v0_nvt_cgdo} CGIDL=0.5 CGSL=1.5e-010
++ CGSO={nfet_06v0_nvt_cgso} CIGBACC=0.075 CIGBINV=0.006 CIGC=0.075 CIGSD=0.075
 + CIT=0 CJS=0.00095 CJSWGS=3.573e-010 CJSWS=1.33e-010 CKAPPAD=0.6 CKAPPAS=0.6
 + CLC=1e-010 CLE=0.6 DELTA=0.005 DIOMOD=1 DLC=0 DLCIG=0 DMCG=0 DMCGT=0 DMDG=0
 + DROUT=0.16 DSUB=0.4 DVT0=2.2 DVT0W=0 DVT1=0.53 DVT1W=5300000 DVT2=-0.032
@@ -37789,8 +37789,8 @@ M0 d g s b nmos_6p0_nat
 + LPEB=0 LU0=0.042 LUB=3.65e-018 LUTE=-0.26 LVTH0=-0.088 LW=0 LWC=0 LWL=0 LWLC=0
 + LWN=1 MINV=-0.5 MJS=0.296 MJSWGS=0.40313 MJSWS=0.01 MOBMOD=0 MOIN=15
 + NDEP=1.7e+017 NFACTOR=0.40241 NGATE=1e+020 NGCON=1 NIGBACC=1 NIGBINV=3 NIGC=1
-+ NJS=1.0541 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.5 NOIA='nmos_6p0_nat_noia'
-+ NOIB='nmos_6p0_nat_noib' NOIC='nmos_6p0_nat_noic' NSD=1e+020 NTNOI=1 NTOX=1
++ NJS=1.0541 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.5 NOIA='nfet_06v0_nvt_noia'
++ NOIB='nfet_06v0_nvt_noib' NOIC='nfet_06v0_nvt_noic' NSD=1e+020 NTNOI=1 NTOX=1
 + PARAMCHK=1 PAT=-10000 PBS=0.606 PBSWGS=0.861 PBSWS=0.48 PCLM=3 PDIBLC1=1.41
 + PDIBLC2=1e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.5 PIGCD=1
 + PKU0=0 PKVTH0=0 POXEDGE=1 PRT=0 PRWB=0 PRWG=1 PSCBE1=5e+009 PSCBE2=5e-006
@@ -37801,17 +37801,17 @@ M0 d g s b nmos_6p0_nat
 + RBSDBYNF=0 RBSDBYW=0 RDSMOD=0 RDSW=3480 RDSWMIN=0 RDW=100 RDWMIN=0 RGATEMOD=0
 + RSH=7 RSHG=0.1 RSW=100 RSWMIN=0 SAREF=1e-006 SBREF=1e-006 SCREF=1e-006 STETA0=0
 + STK2=0 TCJ=0.000825 TCJSW=0.0018 TCJSWG=0.001595 TEMPMOD=0 TKU0=0 TNJTS=0
-+ TNJTSSW=0 TNJTSSWG=0 TNOIMOD=0 TNOM=25 TOXE={nmos_6p0_nat_tox} TOXM=1.52e-008
++ TNJTSSW=0 TNJTSSWG=0 TNOIMOD=0 TNOM=25 TOXE={nfet_06v0_nvt_tox} TOXM=1.52e-008
 + TOXP=1.6e-008 TOXREF=1.52e-008 TPB=0.00146 TPBSW=0.00313 TPBSWG=0.0016588
-+ TRNQSMOD=0 TVFBSDOFF=0 TVOFF=0 U0={nmos_6p0_nat_u0} UA=2.278e-009 UA1=1e-009
++ TRNQSMOD=0 TVFBSDOFF=0 TVOFF=0 U0={nfet_06v0_nvt_u0} UA=2.278e-009 UA1=1e-009
 + UB=3.97e-019 UB1=-1e-018 UC=2.625e-012 UC1=-5.6e-011 UD1=0 UP=0 UTE=-1.5 VBM=-3
 + VFBCV=-1 VFBSDOFF=0 VOFF=-0.06 VOFFCV=0 VOFFL=0 VSAT=106700
-+ VTH0={nmos_6p0_nat_vth0} VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
++ VTH0={nfet_06v0_nvt_vth0} VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
 + VTSSWGS=10 VTSSWS=10 W0=1e-010 WEB=0 WEC=0 WINT=1e-009 WKU0=0 WKVTH0=0 WL=0
 + WLC=0 WLN=1 WLOD=0 WLODKU0=0 WLODVTH=0 WMAX=100.01e-6 WMIN=0.8e-6 WPEMOD=0 WR=1
 + WW=0 WWC=0 WWL=0 WWLC=0 WWN=1 XGL=0 XGW=0 XJ=1.5e-007 XJBVD=1 XJBVS=1
-+ XL={nmos_6p0_nat_xl} XN=3 XPART=0 XRCRG1=12 XRCRG2=1 XTIS=3 XTSD=0.02 XTSS=0.02
-+ XTSSWD=0.02 XTSSWGD=0.02 XTSSWGS=0.02 XTSSWS=0.02 XW={nmos_6p0_nat_xw}
++ XL={nfet_06v0_nvt_xl} XN=3 XPART=0 XRCRG1=12 XRCRG2=1 XTIS=3 XTSD=0.02 XTSS=0.02
++ XTSSWD=0.02 XTSSWGD=0.02 XTSSWGS=0.02 XTSSWS=0.02 XW={nfet_06v0_nvt_xw}
 + LEVEL=14
 **************************************************************
 *               MODEL FLAG PARAMETERS
@@ -37899,7 +37899,7 @@ M0 d g s b nmos_6p0_nat
 
 *               STRESS PARAMETERS
 **************************************************************
-.ENDL nmos_6p0_nat_t
+.ENDL nfet_06v0_nvt_t
 
 
 
@@ -37915,8 +37915,8 @@ M0 d g s b nmos_6p0_nat
 * 6V PMOS Models
 ***************************************************************************************************
 *
-.LIB pmos_6p0_t
-.SUBCKT pmos_6p0_sab d g s b
+.LIB pfet_06v0_t
+.SUBCKT pfet_06v0_dss d g s b
 + PARAMS: W=10u L=0.5u PAR=1 S_SAB=0.28u D_SAB=2.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -37940,15 +37940,15 @@ Xr1 d d1 b pplus_u_m2
 
 Xr2 s s1 b pplus_u_m2
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_6p0
+M0 d1 g s1 b pfet_06v0
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_6p0.0 PMOS
+.MODEL pfet_06v0.0 PMOS
 + A0=0.84 A1=0 A2=1 ACDE=0.7 ACNQSMOD=0 AGIDL=1.1E-15 AGS=0.059 ALPHA0=9.6E-7
 + ALPHA1=51.5 AT=-2.18E4 B0=2.625E-8 B1=0 BETA0=50.8 BGIDL=1.578E5 BINUNIT=1
 + BVD=10.5 BVS=10.5 CAPMOD=2 CDSC=2.4E-4 CDSCB=0 CDSCD=0 CGBO=1E-13
-+ CGDL='5.25E-11*pmos_6p0_dcgdo' CGDO='7.71E-11*pmos_6p0_dcgdo'
-+ CGSL='5.25E-11*pmos_6p0_dcgso' CGSO='7.71E-11*pmos_6p0_dcgso' CIT=0
++ CGDL='5.25E-11*pfet_06v0_dcgdo' CGDO='7.71E-11*pfet_06v0_dcgdo'
++ CGSL='5.25E-11*pfet_06v0_dcgso' CGSO='7.71E-11*pfet_06v0_dcgso' CIT=0
 + CJD=0.000912 CJS=0.000912 CJSWD=1.4649e-010 CJSWGD=3.3229e-010
 + CJSWGS=3.3229e-010 CJSWS=1.4649e-010 CKAPPAD=0.6 CKAPPAS=0.6 DELTA=0.01
 + DIOMOD=1 DLC=7.4E-9 DROUT=0.56 DSUB=0.4824 DVT0=1 DVT0W=0 DVT1=1 DVT1W=5.3E6
@@ -37962,24 +37962,24 @@ M0 d1 g s1 b pmos_6p0
 + LUA1=-6.554813E-10 LUB1=1.939773E-19 LUC=8.691408E-11 LUC1=-1.067674E-10
 + LUTE=-0.152467 LW=0 LWL=-4.76E-21 LWN=1 MINV=0 MJD=0.32713 MJS=0.32713
 + MJSWD=0.056777 MJSWGD=0.50996 MJSWGS=0.50996 MJSWS=0.056777 MOBMOD=0 MOIN=15
-+ NDEP=1.7E17 NFACTOR=1 NGATE=3.6E19 NJD=1 NJS=1 NOFF=1 NOIA='pmos_6p0_noia'
-+ NOIB='pmos_6p0_noib' NOIC='pmos_6p0_noic' NSD=6E16 PAGIDL=6.27545E-16
++ NDEP=1.7E17 NFACTOR=1 NGATE=3.6E19 NJD=1 NJS=1 NOFF=1 NOIA='pfet_06v0_noia'
++ NOIB='pfet_06v0_noib' NOIC='pfet_06v0_noic' NSD=6E16 PAGIDL=6.27545E-16
 + PARAMCHK=1 PAT=-6.1E3 PBD=0.76836 PBETA0=0.14 PBS=0.76836 PBSWD=0.5
 + PBSWGD=1.2295 PBSWGS=1.2295 PBSWS=0.5 PCLM=0.42 PDIBLC1=0.14 PDIBLC2=1E-5
 + PDIBLCB=0 PDITS=0.01 PDITSD=0 PDITSL=0 PERMOD=1 PETAB=-0.012128 PHIN=0
 + PKT1=2.2E-3 PPCLM=0.071 PPRWB=-0.052 PRDSW=-120 PRT=454 PRWB=0.569552
 + PRWG=0.0432 PSCBE1=5.088E8 PSCBE2=1E-8 PUA1=-3.823641E-10 PUB1=7.291324E-19
 + PUC=-1.501336E-11 PUC1=1.8536E-11 PVAG=1.5
-+ PVTH0='7.6E-3+8.47e-3*pmos_6p0_dvth0' RBODYMOD=0 RDSMOD=0 RDSW=1.426E3
++ PVTH0='7.6E-3+8.47e-3*pfet_06v0_dvth0' RBODYMOD=0 RDSMOD=0 RDSW=1.426E3
 + RDSWMIN=100 RSH=7 RSHG=0.1 TCJ=0.001 TCJSW=0.00071888 TCJSWG=0.0009411
-+ TEMPMOD=0 TNOIMOD=0 TNOM=25 TOXE='1.56E-8+pmos_6p0_dtox' TPB=0.0019314
++ TEMPMOD=0 TNOIMOD=0 TNOM=25 TOXE='1.56E-8+pfet_06v0_dtox' TPB=0.0019314
 + TPBSW=0.0017642 TPBSWG=0.0016588 TRNQSMOD=0 U0=0.0151 UA=1.78E-9 UA1=1.41E-9
 + UB=4.88E-19 UB1=-4.31E-18 UC=-2.7435E-11 UC1=1.147552E-10 UTE=-1.2 VFB=-1
-+ VOFF=-0.1284 VOFFCV=0 VOFFL=2.19E-8 VSAT=8.55E4 VTH0='-0.8978+pmos_6p0_dvth0'
++ VOFF=-0.1284 VOFFCV=0 VOFFL=2.19E-8 VSAT=8.55E4 VTH0='-0.8978+pfet_06v0_dvth0'
 + VTL=2E5 W0=3.1E-7 WBETA0=0.22 WINT=4.9E-8 WKETA=2.772E-3 WL=0 WLN=1
 + WMAX=100.01e-6 WMIN=0.3e-6 WR=1 WRDSW=213.9 WUA1=-1.2E-10 WUTE=-0.07
-+ WW=-1.37E-14 WWL=3.04E-22 WWN=1 XJ=1.5E-7 XJBVD=1 XJBVS=1 XL='0+pmos_6p0_dxl'
-+ XN=3 XPART=1 XTID=3 XTIS=3 XW='0+pmos_6p0_dxw'
++ WW=-1.37E-14 WWL=3.04E-22 WWN=1 XJ=1.5E-7 XJBVD=1 XJBVS=1 XL='0+pfet_06v0_dxl'
++ XN=3 XPART=1 XTID=3 XTIS=3 XW='0+pfet_06v0_dxw'
 + LEVEL=14
 ***** Flag Parameter ***
 ***** Geometry Range Parameter ***
@@ -38076,12 +38076,12 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m2
-.ENDL pmos_6p0_t
+.ENDL pfet_06v0_t
 *
 *
 *
 .LIB dio
-.MODEL np_3p3 D
+.MODEL diode_nd2ps_03v3 D
 + CJ='0.00096797* cja' EG=1.17 IBV=0.001 IS='2.2959e-007 * jsa' N=1.01
 + RS='2e-010 * rsa' VB=11.0 XTI=3 TNOM=25 IKF=300000
 + LEVEL=2
@@ -38111,7 +38111,7 @@ Rb 1 2
 
 
 
-.MODEL pn_3p3 D
+.MODEL diode_pd2nw_03v3 D
 + CJ='0.00094344* cja' EG=1.17 IBV=0.001 IS='1.653e-007 * jsa' N=1
 + RS='2e-010 * rsa' VB=10.5 XTI=3
 + LEVEL=2
@@ -38140,11 +38140,11 @@ Rb 1 2
 
 
 
-.MODEL np_6p0 D
+.MODEL diode_nd2ps_06v0 D
 + CJ='0.00095 * cja' EG=1.11 IBV=0.001 IS='6.88e-007 * jsa' N=1.0541
 + RS='2e-010 * rsa' VB=11 XTI=5
 + LEVEL=2
-.MODEL pn_6p0 D
+.MODEL diode_pd2nw_06v0 D
 + BV=10.5 CJ='0.000912 * cja' EG=1.17 IS='2.0867e-007 * jsa' N=1.0058
 + RS='2.0e-010 * rsa' XTI=3
 + LEVEL=2
@@ -38161,7 +38161,7 @@ Rb 1 2
 
 
 
-.MODEL nwp_3p3 D
+.MODEL diode_nw2ps_03v3 D
 + CJ='0.00014917* cja' EG=1.18 IBV=0.001 IS='1.5654e-006 * jsa' N=1.01
 + RS='2e-010 * rsa' VB=0 XTI=3
 + LEVEL=2
@@ -38192,7 +38192,7 @@ Rb 1 2
 
 
 
-.MODEL nwp_6p0 D
+.MODEL diode_nw2ps_06v0 D
 + BV=14 CJ='0.00014914 * cja' EG=1.1763 IS='1.6119e-006 * jsa' N=1
 + RS='2e-010 * rsa' XTI=3
 + LEVEL=2
@@ -38202,7 +38202,7 @@ Rb 1 2
 
 
 
-.MODEL dnwpw D
+.MODEL diode_pw2dw D
 + CJ='0.00032124* cja' EG=1.17 IBV=0.001 IS='5.2139e-007* jsa' N=0.98
 + RS='2e-010* rsa' VB=14.732 XTI=3
 + LEVEL=2
@@ -38212,7 +38212,7 @@ Rb 1 2
 
 
 
-.MODEL dnwps D
+.MODEL diode_dw2ps D
 + CJ='0.00022998* cja' EG=1.17 IBV=0.001 IS='2e-006* jsa' N=0.99335
 + RS='2e-010* rsa' VB=30.48 XTI=3
 + LEVEL=2
@@ -38312,7 +38312,7 @@ Rb 1 2
 * model for substrate capacitor
 
 
-.MODEL np_3p3 D CJ=0.00096797 LEVEL=2
+.MODEL diode_nd2ps_03v3 D CJ=0.00096797 LEVEL=2
 *-------------------
 
 
@@ -38329,13 +38329,13 @@ Rb 1 2
 
 * terminal 1
 Rt1 1 11 nplus_u_t L='s*1u' W={r_w}
-D1 3 1 np_3p3 AREA='r_w*r_l/2'
+D1 3 1 diode_nd2ps_03v3 AREA='r_w*r_l/2'
 * body
 Rb 11 21
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)*(1+mis_r*sw_stat_mismatch)'
 * terminal 2
 Rt2 21 2 nplus_u_t L='s*1u' W={r_w}
-D2 3 2 np_3p3 AREA='r_w*r_l/2'
+D2 3 2 diode_nd2ps_03v3 AREA='r_w*r_l/2'
 *-------------------
 .ENDS nplus_u
 *******************************************************************************************************
@@ -38367,7 +38367,7 @@ D2 3 2 np_3p3 AREA='r_w*r_l/2'
 * model for substrate capacitor
 
 
-.MODEL pn_3p3 D CJ=0.00094344 LEVEL=2
+.MODEL diode_pd2nw_03v3 D CJ=0.00094344 LEVEL=2
 *-------------------
 
 
@@ -38384,13 +38384,13 @@ D2 3 2 np_3p3 AREA='r_w*r_l/2'
 
 * terminal 1
 Rt1 1 11 pplus_u_t L='s*1u' W={r_w}
-D1 1 3 pn_3p3 AREA='r_w*r_l/2'
+D1 1 3 diode_pd2nw_03v3 AREA='r_w*r_l/2'
 * body
 Rb 11 21
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)*(1+mis_r*sw_stat_mismatch)'
 * terminal 2
 Rt2 21 2 pplus_u_t L='s*1u' W={r_w}
-D2 2 3 pn_3p3 AREA='r_w*r_l/2'
+D2 2 3 diode_pd2nw_03v3 AREA='r_w*r_l/2'
 *-------------------
 .ENDS pplus_u
 *******************************************************************************************************
@@ -38416,7 +38416,7 @@ D2 2 3 pn_3p3 AREA='r_w*r_l/2'
 
 
 
-.MODEL np_3p3 D CJ=0.00096797 LEVEL=2
+.MODEL diode_nd2ps_03v3 D CJ=0.00096797 LEVEL=2
 *-------------------
 
 
@@ -38433,13 +38433,13 @@ D2 2 3 pn_3p3 AREA='r_w*r_l/2'
 
 * terminal 1
 Rt1 1 11 nplus_s_t L='s*1u' W={r_w}
-D1 3 1 np_3p3 AREA='r_w*r_l/2'
+D1 3 1 diode_nd2ps_03v3 AREA='r_w*r_l/2'
 * body
 Rb 11 21
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)'
 * terminal 2
 Rt2 21 2 nplus_s_t L='s*1u' W={r_w}
-D2 3 2 np_3p3 AREA='r_w*r_l/2'
+D2 3 2 diode_nd2ps_03v3 AREA='r_w*r_l/2'
 *-------------------
 .ENDS nplus_s
 *******************************************************************************************************
@@ -38465,7 +38465,7 @@ D2 3 2 np_3p3 AREA='r_w*r_l/2'
 
 
 
-.MODEL pn_3p3 D CJ=0.00094344 LEVEL=2
+.MODEL diode_pd2nw_03v3 D CJ=0.00094344 LEVEL=2
 *-------------------
 
 
@@ -38482,13 +38482,13 @@ D2 3 2 np_3p3 AREA='r_w*r_l/2'
 
 * terminal 1
 Rt1 1 11 pplus_s_t L='s*1u' W={r_w}
-D1 1 3 pn_3p3 AREA='r_w*r_l/2'
+D1 1 3 diode_pd2nw_03v3 AREA='r_w*r_l/2'
 * body
 Rb 11 21
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(11,21))/r_n+r_vc2*abs(v(11,21))*abs(v(11,21))/r_n/r_n)'
 * terminal 2
 Rt2 21 2 pplus_s_t L='s*1u' W={r_w}
-D2 2 3 pn_3p3 AREA='r_w*r_l/2'
+D2 2 3 diode_pd2nw_03v3 AREA='r_w*r_l/2'
 *-------------------
 .ENDS pplus_s
 *******************************************************************************************************
@@ -39129,11 +39129,11 @@ Rb 1 2
 *The models are obtained from YI-141-SM003 Rev. 1E.
 *
 * ----------------------------------------------------------------------------------------------------
-.LIB mim_cap
+.LIB cap_mim
 */ -------------------------------------------------------------------------------------
 */ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
 */--------------------------------------------------------------------------------------
-.SUBCKT mim_1p5fF 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.SUBCKT cap_mim_1f5fF 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
 .PARAM
 + C_COX='1.47e-3*mim_corner_1p5fF' C_CAPSW='3.79e-10*mim_corner_1p5fF' C_TNOM=25 C_TC1=4.0604E-05
 + C_TC2=-6.90E-08 C_VCR1=-4.5152E-05 C_VCR2=9.748E-06 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
@@ -39148,11 +39148,11 @@ Rb 1 2
 */ model for capacitance
 C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
 **
-.ENDS mim_1p5fF
+.ENDS cap_mim_1f5
 */ -------------------------------------------------------------------------------------
 */ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
 */--------------------------------------------------------------------------------------
-.SUBCKT mim_1p0fF 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.SUBCKT cap_mim_1f0fF 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
 .PARAM
 + C_COX='0.987e-3*mim_corner_1p0fF' C_CAPSW='3.3e-10*mim_corner_1p0fF' C_TNOM=25 C_TC1=1.302e-5
 + C_TC2=-4.93e-9 C_VCR1=6.079e-6 C_VCR2=1.268e-6 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
@@ -39168,11 +39168,11 @@ C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
 */ model for capacitance
 C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
 **
-.ENDS mim_1p0fF
+.ENDS cap_mim_1f0
 */ -------------------------------------------------------------------------------------
 */ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
 */--------------------------------------------------------------------------------------
-.SUBCKT mim_2p0fF 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.SUBCKT cap_mim_2f0fF 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
 .PARAM GLEAK='9.51e-10/5*10000'
 .PARAM C_COX='1.99e-3*mim_corner_2p0fF'
 .PARAM C_CAPSW='2.383e-10*mim_corner_2p0fF'
@@ -39190,75 +39190,75 @@ C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
 *
 C_cap 1 2 C='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
 R_leak 1 2 R='1/(gleak*c_AREA)' TC1={c_tc1} TC2={c_tc2}
-.ENDS mim_2p0fF
-.ENDL mim_cap
+.ENDS cap_mim_2f0
+.ENDL cap_mim
 * ----------------------------------------------------------------------------------------------------
 *
 *
 .LIB moscap
-.SUBCKT nmoscap_3p3 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_nmos_03v3 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.002003
 .PARAM CVAR2=0.00198
 .PARAM CVAR3=6.25
 .PARAM CVAR4=-3.9375
-C_moscap 1 2 C='nmoscap_3p3_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS nmoscap_3p3
+C_moscap 1 2 C='cap_nmos_03v3_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_nmos_03v3
 *
-.SUBCKT pmoscap_3p3 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_pmos_03v3 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.001998
 .PARAM CVAR2=0.00196
 .PARAM CVAR3=-6.25
 .PARAM CVAR4=-4.9375
-C_moscap 1 2 C='pmoscap_3p3_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS pmoscap_3p3
+C_moscap 1 2 C='cap_pmos_03v3_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_pmos_03v3
 *
-.SUBCKT nmoscap_6p0 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_nmos_06v0 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.001107
 .PARAM CVAR2=0.00107
 .PARAM CVAR3=6.25
 .PARAM CVAR4=-4.1875
-C_moscap 1 2 C='nmoscap_6p0_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS nmoscap_6p0
+C_moscap 1 2 C='cap_nmos_06v0_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_nmos_06v0
 *
-.SUBCKT pmoscap_6p0 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_pmos_06v0 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.001107
 .PARAM CVAR2=0.00107
 .PARAM CVAR3=-6.25
 .PARAM CVAR4=-5.75
-C_moscap 1 2 C='pmoscap_6p0_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS pmoscap_6p0
+C_moscap 1 2 C='cap_pmos_06v0_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_pmos_06v0
 *
-.SUBCKT nmoscap_3p3_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_nmos_03v3_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.002458
 .PARAM CVAR2=0.001533
 .PARAM CVAR3=1.515152
 .PARAM CVAR4=0.560606
-C_moscap 1 2 C='nmoscap_3p3_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS nmoscap_3p3_b
+C_moscap 1 2 C='cap_nmos_03v3_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_nmos_03v3_b
 *
-.SUBCKT pmoscap_3p3_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_pmos_03v3_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.002435
 .PARAM CVAR2=0.00154
 .PARAM CVAR3=-1.66667
 .PARAM CVAR4=0.65
-C_moscap 1 2 C='pmoscap_3p3_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS pmoscap_3p3_b
+C_moscap 1 2 C='cap_pmos_03v3_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_pmos_03v3_b
 *
-.SUBCKT nmoscap_6p0_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_nmos_06v0_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.001293
 .PARAM CVAR2=0.000863
 .PARAM CVAR3=1.052632
 .PARAM CVAR4=0.736842
-C_moscap 1 2 C='nmoscap_6p0_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS nmoscap_6p0_b
+C_moscap 1 2 C='cap_nmos_06v0_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_nmos_06v0_b
 *
-.SUBCKT pmoscap_6p0_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
+.SUBCKT cap_pmos_06v0_b 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0
 .PARAM CVAR1=0.001325
 .PARAM CVAR2=0.000865
 .PARAM CVAR3=-1.42857
 .PARAM CVAR4=0.642857
-C_moscap 1 2 C='pmoscap_6p0_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
-.ENDS pmoscap_6p0_b
+C_moscap 1 2 C='cap_pmos_06v0_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
+.ENDS cap_pmos_06v0_b
 *
 .ENDL moscap
 *
@@ -39266,8 +39266,8 @@ C_moscap 1 2 C='pmoscap_6p0_b_corner*l*w*(cvar1+cvar2*tanh(cvar3*v(1,2)+cvar4))'
 * 3.3V NMOS statistical Models
 ***************************************************************************************************
 *
-.LIB nmos_3p3_stat
-.SUBCKT nmos_3p3_sab d g s b
+.LIB nfet_03v3_stat
+.SUBCKT nfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -39290,10 +39290,10 @@ Xr1 d d1 b nplus_u_m1
 
 Xr2 s s1 b nplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b nmos_3p3
+M0 d1 g s1 b nfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL nmos_3p3.0 NMOS
+.MODEL nfet_03v3.0 NMOS
 + A0=0.11197377 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.32403844
 + ALPHA0=2.652013e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=19.905584
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -39314,8 +39314,8 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-3.8181818e-018 LUTE=9.0909091e-008 LVOFF=3.9354545e-009
 + LVSAT=-0.0027272727 LVTH0=-3.8715455e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.7450182e-015 PAGS=-1.2213818e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.7450182e-015 PAGS=-1.2213818e-014
 + PALPHA0=-1.3658182e-020 PARAMCHK=1 PBETA0=8.7272727e-016 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.3741 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=5.388e-015
@@ -39324,24 +39324,24 @@ M0 d1 g s1 b nmos_3p3
 + PTVOFF=0 PU0=-6.5127273e-016 PUA=-1.4149745e-022 PUB=9.2644364e-032
 + PUB1=-5.7490909e-032 PUC=5.4467782e-024 PUC1=1.8327273e-024
 + PUTE=-4.3636364e-014 PVAG=0 PVOFF=-1.4858182e-015 PVSAT=1.3090909e-009
-+ PVTH0=4.3636364e-016 RBODYMOD=0 RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50
++ PVTH0=4.3636364e-016 RBODYMOD=0 RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50
 + RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438
-+ TCJSW=0.00060474 TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009
-+ TOXP={nmos_3p3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
++ TCJSW=0.00060474 TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009
++ TOXP={nfet_03v3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
 + TRNQSMOD=0 TVOFF=0.001 U0=0.023671338 UA=-1.1554452e-009 UA1=1.675e-009
 + UB=3.3771156e-018 UB1=-4.1945234e-018 UC=2.2660166e-010 UC1=-4.2363636e-011
 + UTE=-1.5675325 VBM=-3 VFBCV=-1 VOFF=-0.1262652 VOFFCV=0.005 VOFFL=0
-+ VSAT=92454.546 VTH0={nmos_3p3_vth0_0} W0=5e-007 WA0=-6.2322078e-009
++ VSAT=92454.546 VTH0={nfet_03v3_vth0_0} W0=5e-007 WA0=-6.2322078e-009
 + WAGS=4.7930493e-008 WALPHA0=4.8779221e-014 WBETA0=1.3848312e-007 WINT=1e-008
 + WK2=-1.9242857e-008 WKETA=8.1643636e-009 WKT1=3.2086753e-008
 + WKT2=1.0597403e-009 WL=0 WLN=1 WMAX=5e-007 WMIN=2.2e-007 WPCLM=2.1028364e-008
 + WR=1 WTVOFF=0 WU0=4.6066597e-009 WUA=2.7073777e-016 WUB=-4.093733e-025
 + WUB1=3.3492467e-025 WUC=-3.2577351e-017 WUC1=-6.5454545e-018
 + WUTE=1.0441558e-007 WVOFF=5.3064935e-009 WVSAT=-0.00021818182
-+ WVTH0=-1.430587e-008 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl} XPART=0
-+ XTIS=3 XW={nmos_3p3_xw}
++ WVTH0=-1.430587e-008 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl} XPART=0
++ XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
-.MODEL nmos_3p3.1 NMOS
+.MODEL nfet_03v3.1 NMOS
 + A0=1.0861147 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.47870122
 + ALPHA0=6.5720816e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=22.625306
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -39362,7 +39362,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=5.1428571e-018 LVOFF=-2.8273469e-009 LVSAT=0.0017142857
 + LVTH0=-2.3433061e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=2.4627526e-014 PAGS=-9.9007347e-015 PALPHA0=1.8396735e-020
 + PARAMCHK=1 PBETA0=2.4538775e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.082893878 PDIBLC1=0.39 PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0
@@ -39371,21 +39371,21 @@ M0 d1 g s1 b nmos_3p3
 + PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PU0=1.2234122e-015
 + PUA=-2.976098e-023 PUB=-9.8501878e-032 PUB1=8.1521633e-032 PUC=-1.1961815e-023
 + PUC1=-2.4685714e-024 PVAG=0 PVOFF=3.2032653e-016 PVSAT=2.0571429e-009
-+ PVTH0=-5.642449e-016 RBODYMOD=0 RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50
++ PVTH0=-5.642449e-016 RBODYMOD=0 RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50
 + RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438
-+ TCJSW=0.00060474 TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009
-+ TOXP={nmos_3p3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
++ TCJSW=0.00060474 TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009
++ TOXP={nfet_03v3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
 + TRNQSMOD=0 TVOFF=0.001 U0=0.029675694 UA=-1.2961984e-009 UA1=1.675e-009
 + UB=3.0836898e-018 UB1=-2.804398e-018 UC=8.4613959e-011 UC1=-6.0285714e-011
 + UTE=-1.3857143 VBM=-3 VFBCV=-1 VOFF=-0.11273959 VOFFCV=0.005 VOFFL=0
-+ VSAT=83571.429 VTH0={nmos_3p3_vth0_1} W0=5e-007 WA0=-5.1997224e-008
++ VSAT=83571.429 VTH0={nfet_03v3_vth0_1} W0=5e-007 WA0=-5.1997224e-008
 + WAGS=4.3304327e-008 WALPHA0=-1.5330612e-014 WBETA0=-3.5054694e-007 WINT=1e-008
 + WK2=-3.01296e-009 WKETA=-7.4262857e-009 WKT1=-2.4641633e-009
 + WKT2=-3.9183673e-011 WL=0 WLN=1 WMAX=5e-007 WMIN=2.2e-007 WPCLM=4.3902367e-008
 + WR=1 WTVOFF=0 WU0=8.572898e-010 WUA=4.7264816e-017 WUB=-2.7080816e-026
 + WUB1=5.6899592e-026 WUC=2.2398367e-018 WUC1=2.0571429e-018 WUTE=1.7142857e-008
 + WVOFF=1.6942041e-009 WVSAT=-0.0017142857 WVTH0=-1.2304653e-008 WW=0 WWL=0 WWN=1
-+ XJ={nmos_3p3_xj} XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ XJ={nfet_03v3_xj} XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -39539,7 +39539,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.2 NMOS
+.MODEL nfet_03v3.2 NMOS
 + A0=1.224418 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.25784649
 + ALPHA0=7.5243347e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.210162
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -39559,8 +39559,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-2.347987e-025 LUB1=-7.5296104e-025 LUC=-6.9921429e-018
 + LVOFF=1.3461039e-008 LVTH0=-3.224026e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-4.2919481e-014 PAGS=4.5191688e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-4.2919481e-014 PAGS=4.5191688e-014
 + PALPHA0=-9.043013e-018 PARAMCHK=1 PBETA0=-3.1184416e-013 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.18918506 PDIBLC1=0.39 PDIBLC2=0.00064013636
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=2.6091117e-015
@@ -39568,20 +39568,20 @@ M0 d1 g s1 b nmos_3p3
 + PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PU0=1.447013e-015
 + PUA=1.9701818e-023 PUB=-1.1174026e-031 PUB1=1.231013e-031 PUC=1.4030649e-024
 + PVAG=0 PVOFF=-1.4493507e-016 PVTH0=-3.6888312e-015 RBODYMOD=0 RDSMOD=0
-+ RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.032447266 UA=-8.1547091e-010 UA1=1.675e-009 UB=2.7427942e-018
 + UB1=-2.5166039e-018 UC=9.84685e-011 UC1=-5.6e-011 UTE=-1.3857143 VBM=-3
 + VFBCV=-1 VOFF=-0.12631325 VOFFCV=0.005 VOFFL=0 VSAT=85000
-+ VTH0={nmos_3p3_vth0_2} W0=5e-007 WA0=4.291948e-009 WAGS=-2.606026e-009
++ VTH0={nfet_03v3_vth0_2} W0=5e-007 WA0=4.291948e-009 WAGS=-2.606026e-009
 + WALPHA0=7.5358442e-012 WBETA0=1.1381299e-007 WINT=1e-008 WK2=-7.4596769e-009
 + WKETA=-6.5992208e-010 WKT1=-7.3528831e-009 WKT2=1.7142857e-010 WL=0 WLN=1
 + WMAX=5e-007 WMIN=2.2e-007 WPCLM=2.1551688e-009 WR=1 WTVOFF=0 WU0=6.7095584e-010
 + WUA=6.0458182e-018 WUB=-1.6048831e-026 WUB1=2.224987e-026 WUC=-8.8975636e-018
 + WUTE=1.7142857e-008 WVOFF=2.0819221e-009 WVTH0=-9.7008312e-009 WW=0 WWL=0 WWN=1
-+ XJ={nmos_3p3_xj} XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ XJ={nfet_03v3_xj} XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -39782,7 +39782,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.3 NMOS
+.MODEL nfet_03v3.3 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.27510429
 + ALPHA0=6.6776286e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.896857
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -39796,25 +39796,25 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.022847143 KT1=-0.332 KT1L=0 KT2=-0.021107143 KU0=0 KVSAT=0 KVTH0=0
 + LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0
 + LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0
-+ MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.18626143 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
-+ RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.032279714 UA=-7.959e-010 UA1=1.675e-009 UB=2.7193143e-018
 + UB1=-2.5919e-018 UC=9.7769286e-011 UC1=-5.6e-011 UTE=-1.3857143 VBM=-3 VFBCV=-1
-+ VOFF=-0.12496714 VOFFCV=0.005 VOFFL=0 VSAT=85000 VTH0={nmos_3p3_vth0_3}
++ VOFF=-0.12496714 VOFFCV=0.005 VOFFL=0 VSAT=85000 VTH0={nfet_03v3_vth0_3}
 + W0=5e-007 WAGS=1.9131429e-009 WALPHA0=6.6315429e-012 WBETA0=8.2628571e-008
 + WINT=1e-008 WK2=-7.1987657e-009 WKETA=-9.3497143e-010 WKT1=-5.904e-009
 + WKT2=1.7142857e-010 WL=0 WLN=1 WMAX=5e-007 WMIN=2.2e-007 WPCLM=6.8777143e-009
 + WR=1 WTVOFF=0 WU0=8.1565714e-010 WUA=8.016e-018 WUB=-2.7222857e-026
 + WUB1=3.456e-026 WUC=-8.7572571e-018 WUTE=1.7142857e-008 WVOFF=2.0674286e-009
-+ WVTH0=-1.0069714e-008 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl}
-+ XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WVTH0=-1.0069714e-008 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl}
++ XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -40017,7 +40017,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.4 NMOS
+.MODEL nfet_03v3.4 NMOS
 + A0=0.10680558 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.35500309
 + ALPHA0=2.6500109e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=20.982852
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -40037,8 +40037,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB=-9.0230909e-026 LUB1=2.4878e-025 LUC=-3.4349127e-017 LVOFF=-9.2114546e-009
 + LVSAT=0.0042909091 LVTH0=-4.1979273e-008 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=1.0504145e-015 PAGS=-1.3815011e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=1.0504145e-015 PAGS=-1.3815011e-014
 + PALPHA0=-2.4870109e-020 PARAMCHK=1 PBETA0=1.0555636e-013 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.45921829 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PK2=3.5791331e-015
@@ -40047,21 +40047,21 @@ M0 d1 g s1 b nmos_3p3
 + PTVOFF=0 PU0=-3.5013818e-016 PUA=3.8566691e-024 PUB=-2.4352626e-031
 + PUB1=-3.8927127e-032 PUC=-7.5187026e-024 PVAG=0 PVOFF=4.8246982e-015
 + PVSAT=-2.0596364e-009 PVTH0=2.0029964e-015 RBODYMOD=0 RDSMOD=0
-+ RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.033011551 UA=-6.3005701e-010 UA1=1.675e-009 UB=2.2836418e-018
 + UB1=-3.65896e-018 UC=1.5877203e-010 UC1=-5.6e-011 UTE=-1.4342857 VBM=-3
 + VFBCV=-1 VOFF=-0.079311948 VOFFCV=0.005 VOFFL=0 VSAT=71618.182
-+ VTH0={nmos_3p3_vth0_4} W0=5e-007 WA0=-3.7514805e-009 WAGS=3.3067462e-008
++ VTH0={nfet_03v3_vth0_4} W0=5e-007 WA0=-3.7514805e-009 WAGS=3.3067462e-008
 + WALPHA0=4.9740218e-014 WBETA0=-3.786053e-007 WINT=1e-008 WK2=-1.2782618e-008
 + WKETA=-3.3798633e-009 WKT1=-7.0851491e-009 WKT2=-3.8010589e-009 WL=0 WLN=1
 + WMAX=1.2e-006 WMIN=5e-007 WPCLM=-1.9828414e-008 WR=1 WTVOFF=0
 + WU0=1.2335751e-010 WUA=1.8551439e-017 WUB=1.1549411e-025 WUB1=7.7854254e-026
 + WUC=-1.9125195e-020 WUTE=4.0457143e-008 WVOFF=-1.7231065e-008
-+ WVSAT=0.0097832727 WVTH0=-2.1596758e-008 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj}
-+ XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WVSAT=0.0097832727 WVTH0=-2.1596758e-008 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj}
++ XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -40218,7 +40218,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.5 NMOS
+.MODEL nfet_03v3.5 NMOS
 + A0=0.97533082 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.441074
 + ALPHA0=6.8164074e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.036008
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -40239,7 +40239,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=3.1443869e-017 LVOFF=1.1378694e-008 LVSAT=-0.0041142857
 + LVTH0=-1.7716408e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.4148441e-015 PAGS=-2.7963977e-014 PALPHA0=6.6303478e-020
 + PARAMCHK=1 PBETA0=-2.8990433e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.21719837 PDIBLC1=0.39 PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0
@@ -40248,21 +40248,21 @@ M0 d1 g s1 b nmos_3p3
 + PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PU0=-3.5579167e-016
 + PUA=2.2512666e-023 PUB=-2.3455895e-031 PUB1=-2.9753339e-032 PUC=-9.2762449e-024
 + PUC1=-1.5093057e-023 PVAG=0 PVOFF=-6.4985731e-015 PVSAT=4.8548571e-009
-+ PVTH0=-3.3082384e-015 RBODYMOD=0 RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50
++ PVTH0=-3.3082384e-015 RBODYMOD=0 RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50
 + RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438
-+ TCJSW=0.00060474 TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009
-+ TOXP={nmos_3p3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
++ TCJSW=0.00060474 TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009
++ TOXP={nfet_03v3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
 + TRNQSMOD=0 TVOFF=0.001 U0=0.031181163 UA=-1.1586455e-009 UA1=1.675e-009
 + UB=2.8240225e-018 UB1=-2.8098294e-018 UC=8.1997037e-011 UC1=-1.1888774e-010
 + UTE=-1.4342857 VBM=-3 VFBCV=-1 VOFF=-0.12049225 VOFFCV=0.005 VOFFL=0
-+ VSAT=88428.571 VTH0={nmos_3p3_vth0_5} W0=5e-007 WA0=1.1790367e-009
++ VSAT=88428.571 VTH0={nfet_03v3_vth0_5} W0=5e-007 WA0=1.1790367e-009
 + WAGS=6.1365394e-008 WALPHA0=-1.3260696e-013 WBETA0=4.1231608e-007 WINT=1e-008
 + WK1=-1.0528104e-008 WK2=4.4440669e-009 WKT1=3.0571729e-008 WKT2=5.2016327e-009
 + WL=0 WLN=1 WMAX=1.2e-006 WMIN=5e-007 WPCLM=-2.0563788e-008 WR=1 WTVOFF=0
 + WU0=1.3466449e-010 WUA=-1.8760555e-017 WUB=9.755951e-026 WUB1=5.9506678e-026
 + WUC=3.4959595e-018 WUC1=3.0186115e-017 WUTE=4.0457143e-008 WVOFF=5.4154776e-009
-+ WVSAT=-0.0040457143 WVTH0=-1.0974289e-008 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj}
-+ XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WVSAT=-0.0040457143 WVTH0=-1.0974289e-008 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj}
++ XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -40457,7 +40457,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.6 NMOS
+.MODEL nfet_03v3.6 NMOS
 + A0=1.2333595 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.28370796
 + ALPHA0=9.0921047e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.039866
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -40478,7 +40478,7 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=-5.0024338e-017 LUTE=3.448052e-007 LVOFF=1.3159091e-008
 + LVTH0=1.325026e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PAGS=6.3697932e-014 PALPHA0=-1.0548281e-019 PARAMCHK=1
 + PBETA0=-2.9791169e-014 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22708279
 + PDIBLC1=0.39 PDIBLC2=0.00064013636 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -40487,20 +40487,20 @@ M0 d1 g s1 b nmos_3p3
 + PSCBE2=1.638e-005 PTVOFF=0 PU0=1.3295688e-015 PUA=8.5070338e-024
 + PUB=8.4187636e-032 PUB1=-5.7827969e-031 PUC=5.071119e-024 PUC1=2.4011682e-023
 + PUTE=-1.6550649e-013 PVAG=0 PVTH0=-1.1596488e-014 RBODYMOD=0 RDSMOD=0
-+ RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.036490513 UA=-7.881063e-010 UA1=1.675e-009 UB=3.0594896e-018
 + UB1=-3.5465249e-018 UC=9.7557278e-011 UC1=-5.0997566e-011 UTE=-1.7216234 VBM=-3
 + VFBCV=-1 VOFF=-0.12197591 VOFFCV=0.005 VOFFL=0 VSAT=85000
-+ VTH0={nmos_3p3_vth0_6} W0=5e-007 WAGS=-1.501953e-008 WALPHA0=1.0548281e-014
++ VTH0={nfet_03v3_vth0_6} W0=5e-007 WAGS=-1.501953e-008 WALPHA0=1.0548281e-014
 + WBETA0=1.9555512e-007 WINT=1e-008 WK1=8.3746286e-010 WK2=-2.005398e-009
 + WKT1=-2.4318421e-009 WKT2=5.0571429e-010 WL=0 WLN=1 WMAX=1.2e-006 WMIN=5e-007
 + WPCLM=-1.603574e-008 WR=1 WTVOFF=0 WU0=-1.2698026e-009 WUA=-7.0891948e-018
 + WUB=-1.6806265e-025 WUB1=5.1661197e-025 WUC=-8.460177e-018 WUC1=-2.4011682e-018
-+ WUTE=1.7837922e-007 WVTH0=-4.067414e-009 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj}
-+ XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WUTE=1.7837922e-007 WVTH0=-4.067414e-009 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj}
++ XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -40700,7 +40700,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.7 NMOS
+.MODEL nfet_03v3.7 NMOS
 + A0=1.1588 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29711029
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=23.6678 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1e-010
@@ -40714,24 +40714,24 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.3443 KT1L=0 KT2=-0.022435714 KU0=0 KVSAT=0 KVTH0=0 LINT=0
 + LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0
 + LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.22998886 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
-+ RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.036347429 UA=-7.6620314e-010 UA1=1.675e-009 UB=2.9951914e-018
 + UB1=-3.4757e-018 UC=9.6093886e-011 UC1=-5.6e-011 UTE=-1.6871429 VBM=-3 VFBCV=-1
-+ VOFF=-0.12066 VOFFCV=0.005 VOFFL=0 VSAT=85000 VTH0={nmos_3p3_vth0_7} W0=5e-007
++ VOFF=-0.12066 VOFFCV=0.005 VOFFL=0 VSAT=85000 VTH0={nfet_03v3_vth0_7} W0=5e-007
 + WAGS=-8.6497371e-009 WBETA0=1.92576e-007 WINT=1e-008 WK2=-1.7348832e-009
 + WKT2=8.0914286e-010 WL=0 WLN=1 WMAX=1.2e-006 WMIN=5e-007 WPCLM=-1.4111451e-008
 + WR=1 WTVOFF=0 WU0=-1.1368457e-009 WUA=-6.2384914e-018 WUB=-1.5964389e-025
 + WUB1=4.58784e-025 WUC=-7.9530651e-018 WUTE=1.6182857e-007 WVTH0=-5.2270629e-009
-+ WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl} XPART=0 XTIS=3
-+ XW={nmos_3p3_xw}
++ WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl} XPART=0 XTIS=3
++ XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -40938,7 +40938,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.8 NMOS
+.MODEL nfet_03v3.8 NMOS
 + A0=0.10362636 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.2705431
 + ALPHA0=2.5953123e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.140586
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -40959,7 +40959,7 @@ M0 d1 g s1 b nmos_3p3
 + LVOFF=6.8691116e-010 LVOFFCV=-1.118626e-007 LVSAT=-0.00034132231
 + LVTH0=-5.5747725e-008 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01
-+ NOFF=-0.59809917 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic}
++ NOFF=-0.59809917 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PAGS=-6.6365124e-014 PALPHA0=-5.7142305e-020 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.20476889 PDIBLC1=0.39
 + PDIBLC2=0.003171 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07
@@ -40969,22 +40969,22 @@ M0 d1 g s1 b nmos_3p3
 + PUA=1.7471409e-022 PUB=4.2239319e-032 PUB1=-3.1500653e-031 PUC=3.2259428e-023
 + PUC1=-5.8684551e-023 PVAG=0 PVOFF=-6.8553733e-015 PVOFFCV=1.3199787e-013
 + PVSAT=3.4063967e-009 PVTH0=1.824977e-014 RBODYMOD=0 RDSMOD=0
-+ RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.046898182 UA=-6.6207759e-010 UA1=1.675e-009 UB=3.7962141e-018
 + UB1=-5.3788142e-018 UC=2.9436835e-010 UC1=-2.2938539e-010 UTE=-1.5701136 VBM=-3
 + VFBCV=-1 VOFF=-0.12424632 VOFFCV=0.22872521 VOFFL=0 VSAT=85682.645
-+ VTH0={nmos_3p3_vth0_8} W0=5e-007 WAGS=1.3273025e-007 WALPHA0=1.1428461e-013
++ VTH0={nfet_03v3_vth0_8} W0=5e-007 WAGS=1.3273025e-007 WALPHA0=1.1428461e-013
 + WBETA0=-5.6473191e-007 WINT=1e-008 WK1=1.0355446e-008 WK2=1.9443834e-008
 + WKETA=-4.1694295e-009 WKT1=-1.2105482e-007 WKT2=8.9970236e-009 WL=0 WLN=1
 + WMAX=1e-005 WMIN=1.2e-006 WNOFF=3.065757e-006 WPCLM=2.8042187e-007 WR=1
 + WTVOFF=0 WU0=-1.6262868e-008 WUA=5.6335718e-017 WUB=-1.6693412e-024
 + WUB1=2.1072821e-024 WUC=-1.6002278e-016 WUC1=2.0459475e-016 WUTE=2.0073409e-007
 + WVOFF=3.5791497e-008 WVOFFCV=-2.6399574e-007 WVSAT=-0.0068127934
-+ WVTH0=-5.7737207e-008 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl}
-+ XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WVTH0=-5.7737207e-008 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl}
++ XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -41135,7 +41135,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.9 NMOS
+.MODEL nfet_03v3.9 NMOS
 + A0=0.57970277 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.63340774
 + ALPHA0=6.7040286e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.043581
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -41155,8 +41155,8 @@ M0 d1 g s1 b nmos_3p3
 + LUB1=-6.899552e-025 LUC=5.1261039e-019 LUC1=7.5986727e-018
 + LVOFF=-1.0167857e-008 LVTH0=-9.953513e-009 LW=0 LWL=0 LWN=1 MINV=-0.25
 + MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1
-+ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-2.3401007e-013 PAGS=8.279421e-014
++ NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-2.3401007e-013 PAGS=8.279421e-014
 + PARAMCHK=1 PBETA0=-4.8405592e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062
 + PCLM=0.047719 PDIBLC1=0.39 PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0
 + PDITSL=0 PERMOD=1 PHIN=0.07 PK2=7.3331031e-015 PKT1=2.1335166e-014
@@ -41164,20 +41164,20 @@ M0 d1 g s1 b nmos_3p3
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PU0=2.9708645e-016
 + PUA=3.4779762e-022 PUB=-4.5859137e-031 PUB1=5.7696713e-031 PUC=-5.1158517e-024
 + PUC1=1.3044275e-023 PVAG=0 PVOFF=1.8926357e-014 PVTH0=-1.2468455e-014
-+ RBODYMOD=0 RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7
++ RBODYMOD=0 RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7
 + RSWMIN=0 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474
-+ TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009
-+ TOXP={nmos_3p3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
++ TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009
++ TOXP={nfet_03v3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
 + TRNQSMOD=0 TVOFF=0.001 U0=0.038465008 UA=-9.289245e-010 UA1=1.675e-009
 + UB=3.4725304e-018 UB1=-3.0334126e-018 UC=1.5722431e-010 UC1=-1.4511739e-010
 + UTE=-1.5701136 VBM=-3 VFBCV=-1 VOFF=-0.10253679 VOFFCV=0.005 VOFFL=0 VSAT=85000
-+ VTH0={nmos_3p3_vth0_9} W0=5e-007 WA0=4.6802014e-007 WAGS=-1.6558842e-007
++ VTH0={nfet_03v3_vth0_9} W0=5e-007 WA0=4.6802014e-007 WAGS=-1.6558842e-007
 + WBETA0=4.0337993e-007 WINT=1e-008 WK2=-6.1109193e-009 WKT1=-9.3348999e-008
 + WKT2=-5.9264351e-009 WL=0 WLN=1 WMAX=1e-005 WMIN=1.2e-006 WPCLM=1.7942187e-007
 + WR=1 WTVOFF=0 WU0=-8.4602728e-009 WUA=-2.8983135e-016 WUB=-6.6767982e-025
 + WUB1=3.2333483e-025 WUC=-8.5272224e-017 WUC1=6.1137104e-017 WUTE=2.0073409e-007
-+ WVOFF=-1.5771964e-008 WVTH0=3.6992425e-009 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj}
-+ XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WVOFF=-1.5771964e-008 WVTH0=3.6992425e-009 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj}
++ XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -41381,7 +41381,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.10 NMOS
+.MODEL nfet_03v3.10 NMOS
 + A0=1.175342 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26729169
 + ALPHA0=9.0929986e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.512311
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -41403,7 +41403,7 @@ M0 d1 g s1 b nmos_3p3
 + LUTE=-2.7427686e-008 LVOFF=1.3159091e-008 LVOFFCV=8.5056818e-008
 + LVTH0=7.3817355e-009 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059
 + MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01
-+ NOFF=2.128874 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic}
++ NOFF=2.128874 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PA0=2.454613e-013 PAGS=-1.211339e-013 PARAMCHK=1
 + PBETA0=4.3431558e-013 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23344442
 + PDIBLC1=0.39 PDIBLC2=0.00064013636 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0
@@ -41413,21 +41413,21 @@ M0 d1 g s1 b nmos_3p3
 + PUA=-2.3522386e-023 PUA1=-3.065757e-023 PUB=-8.7392324e-031 PUB1=2.3248657e-030
 + PUC=-8.7702549e-023 PUC1=9.8191818e-023 PUTE=2.7372831e-013 PVAG=0
 + PVOFFCV=-1.0036705e-013 PVTH0=-4.6716298e-015 RBODYMOD=0 RDSMOD=0
-+ RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.040494054 UA=-8.1072595e-010 UA1=1.6533492e-009
 + UB=3.1895805e-018 UB1=-2.1483391e-018 UC=1.0432829e-010 UC1=-4.4711114e-011
 + UTE=-1.5472572 VBM=-3 VFBCV=-1 VOFF=-0.12197591 VOFFCV=-0.065880682 VOFFL=0
-+ VSAT=85000 VTH0={nmos_3p3_vth0_10} W0=5e-007 WA0=6.8460666e-008
++ VSAT=85000 VTH0={nfet_03v3_vth0_10} W0=5e-007 WA0=6.8460666e-008
 + WAGS=4.3516718e-009 WBETA0=-3.6192965e-007 WINT=1e-008 WK1=-3.0414256e-009
 + WKT1=-3.095198e-008 WKT2=-5.3833233e-009 WL=0 WLN=1 WMAX=1e-005 WMIN=1.2e-006
 + WNOFF=-1.5207128e-007 WPCLM=-2.3542459e-008 WR=1 WTVOFF=0 WU0=-5.9939808e-009
 + WUA=1.9601988e-017 WUA1=2.5547975e-017 WUB=-3.2156993e-025 WUB1=-1.1332474e-024
 + WUC=-1.6449976e-017 WUC1=-9.8191818e-018 WUTE=-2.7372831e-008
-+ WVOFFCV=8.3639205e-008 WVTH0=-2.7981116e-009 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj}
-+ XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WVOFFCV=8.3639205e-008 WVTH0=-2.7981116e-009 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj}
++ XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -41616,7 +41616,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.11 NMOS
+.MODEL nfet_03v3.11 NMOS
 + A0=1.0799807 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29635773
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.100914
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -41631,24 +41631,24 @@ M0 d1 g s1 b nmos_3p3
 + LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0
 + LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0
 + MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1134091
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803
 + PDIBLC1=0.39 PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0.07 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0
-+ PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0
++ PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0
 + RSH=7 RSWMIN=0 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474
-+ TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009
-+ TOXP={nmos_3p3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
++ TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009
++ TOXP={nfet_03v3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
 + TRNQSMOD=0 TVOFF=0.001 U0=0.040689277 UA=-7.8610843e-010 UA1=1.6559473e-009
 + UB=3.2064782e-018 UB1=-2.3235434e-018 UC=1.1072708e-010 UC1=-5.6e-011 UTE=-1.55
 + VBM=-3 VFBCV=-1 VOFF=-0.12066 VOFFCV=-0.057375 VOFFL=0 VSAT=85000
-+ VTH0={nmos_3p3_vth0_11} W0=5e-007 WA0=9.3006796e-008 WAGS=-7.7617182e-009
++ VTH0={nfet_03v3_vth0_11} W0=5e-007 WA0=9.3006796e-008 WAGS=-7.7617182e-009
 + WBETA0=-3.1849809e-007 WINT=1e-008 WK1=-2.6764545e-009 WKT1=-3.6306106e-008
 + WKT2=-5.0183523e-009 WL=0 WLN=1 WMAX=1e-005 WMIN=1.2e-006 WNOFF=-1.3382273e-007
 + WR=1 WTVOFF=0 WU0=-6.2602272e-009 WUA=1.7249749e-017 WUA1=2.2482218e-017
 + WUB=-4.0896225e-025 WUB1=-9.0076078e-025 WUC=-2.5220231e-017
-+ WVOFFCV=7.36025e-008 WVTH0=-3.2652745e-009 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj}
-+ XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WVOFFCV=7.36025e-008 WVTH0=-3.2652745e-009 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj}
++ XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -41861,7 +41861,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.12 NMOS
+.MODEL nfet_03v3.12 NMOS
 + A0=0.13211844 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.46155061
 + ALPHA0=2.6067636e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -41882,22 +41882,22 @@ M0 d1 g s1 b nmos_3p3
 + LUC1=4.3852454e-017 LVOFFCV=-9.8636364e-008 LVTH0=-5.3919091e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
 + NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=-0.29090909
-+ NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020
++ NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=1.4217547e-013 PAGS=8.8676235e-013 PARAMCHK=1 PBS=0.70172
 + PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.23286727 PDIBLC1=0.39 PDIBLC2=0.003171
 + PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PKETA=1.7976533e-014
 + PRT=0 PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0
-+ RBODYMOD=0 RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7
++ RBODYMOD=0 RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7
 + RSWMIN=0 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474
-+ TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009
-+ TOXP={nmos_3p3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
++ TCJSWG=0.001 TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009
++ TOXP={nfet_03v3_tox} TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872
 + TRNQSMOD=0 TVOFF=0.001 U0=0.045268636 UA=-6.5643273e-010 UA1=1.675e-009
 + UB=3.6289455e-018 UB1=-5.1676636e-018 UC=2.78334e-010 UC1=-2.0888491e-010
 + UTE=-1.55 VBM=-3 VFBCV=-1 VOFF=-0.12066 VOFFCV=0.20227273 VOFFL=0 VSAT=85000
-+ VTH0={nmos_3p3_vth0_12} W0=5e-007 WA0=-2.8435094e-007 WAGS=-1.7735247e-006
++ VTH0={nfet_03v3_vth0_12} W0=5e-007 WA0=-2.8435094e-007 WAGS=-1.7735247e-006
 + WINT=1e-008 WKETA=-3.5953066e-008 WL=0 WLN=1 WMAX=0.000100001 WMIN=1e-005 WR=1
-+ WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl} XPART=0 XTIS=3
-+ XW={nmos_3p3_xw}
++ WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl} XPART=0 XTIS=3
++ XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -42061,7 +42061,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.13 NMOS
+.MODEL nfet_03v3.13 NMOS
 + A0=0.62659857 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.61681571
 + ALPHA0=6.7040286e-006 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=21.084
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -42080,21 +42080,21 @@ M0 d1 g s1 b nmos_3p3
 + LU0=4.4168571e-009 LUA=4.2286286e-016 LUB=-2.1651429e-025 LUB1=-6.3214286e-025
 + LUC1=8.9057143e-018 LVOFF=-8.2714286e-009 LVTH0=-1.1202857e-008 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.065697143 PDIBLC1=0.39
 + PDIBLC2=0.001359 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
-+ RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.037617286 UA=-9.5796571e-010 UA1=1.675e-009 UB=3.4056286e-018
 + UB1=-3.0010143e-018 UC=1.4868e-010 UC1=-1.3899143e-010 UTE=-1.55 VBM=-3
 + VFBCV=-1 VOFF=-0.10411714 VOFFCV=0.005 VOFFL=0 VSAT=85000
-+ VTH0={nmos_3p3_vth0_13} W0=5e-007 WINT=1e-008 WL=0 WLN=1 WMAX=0.000100001
-+ WMIN=1e-005 WR=1 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl}
-+ XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ VTH0={nfet_03v3_vth0_13} W0=5e-007 WINT=1e-008 WL=0 WLN=1 WMAX=0.000100001
++ WMIN=1e-005 WR=1 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl}
++ XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -42271,7 +42271,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.14 NMOS
+.MODEL nfet_03v3.14 NMOS
 + A0=1.1822018 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.26772773
 + ALPHA0=9.0929986e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.476046
 + BGIDL=1.8961e+009 BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013
@@ -42292,21 +42292,21 @@ M0 d1 g s1 b nmos_3p3
 + LUB1=-1.5190909e-024 LUC=5.52e-017 LUC1=-1.0305e-016 LVOFF=1.3159091e-008
 + LVOFFCV=7.5e-008 LVTH0=6.9136364e-009 LW=0 LWL=0 LWN=1 MINV=-0.25 MJS=0.32071
 + MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15 NDEP=3e+017 NFACTOR=1 NGATE=6e+019
-+ NJS=1.01 NOFF=2.1136364 NOIA={nmos_3p3_noia} NOIB={nmos_3p3_noib}
-+ NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
++ NJS=1.01 NOFF=2.1136364 NOIA={nfet_03v3_noia} NOIB={nfet_03v3_noib}
++ NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.70172 PBSWGS=0.74743
 + PBSWS=0.8062 PCLM=0.23108545 PDIBLC1=0.39 PDIBLC2=0.00064013636 PDIBLCB=0.2
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
-+ RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.039893455 UA=-8.0876182e-010 UA1=1.6559091e-009
 + UB=3.1573591e-018 UB1=-2.2618909e-018 UC=1.0268e-010 UC1=-4.5695e-011 UTE=-1.55
 + VBM=-3 VFBCV=-1 VOFF=-0.12197591 VOFFCV=-0.0575 VOFFL=0 VSAT=85000
-+ VTH0={nmos_3p3_vth0_14} W0=5e-007 WINT=1e-008 WL=0 WLN=1 WMAX=0.000100001
-+ WMIN=1e-005 WR=1 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl}
-+ XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ VTH0={nfet_03v3_vth0_14} W0=5e-007 WINT=1e-008 WL=0 WLN=1 WMAX=0.000100001
++ WMIN=1e-005 WR=1 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl}
++ XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -42473,7 +42473,7 @@ M0 d1 g s1 b nmos_3p3
 
 
 
-.MODEL nmos_3p3.15 NMOS
+.MODEL nfet_03v3.15 NMOS
 + A0=1.0893 A1=0 A2=1 ACDE=0.6 ACNQSMOD=0 AGIDL=1.3268e-010 AGS=0.29558
 + ALPHA0=8.0592e-005 ALPHA1=0 AT=23000 B0=0 B1=0 BETA0=24.069 BGIDL=1.8961e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=1e-010
@@ -42487,20 +42487,20 @@ M0 d1 g s1 b nmos_3p3
 + KETA=-0.024795 KT1=-0.31717 KT1L=0 KT2=-0.018 KU0=0 KVSAT=0 KVTH0=0 LINT=0 LL=0
 + LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=1.1e-007 LPEB=0 LTVOFF=0 LW=0 LWL=0
 + LWN=1 MINV=-0.25 MJS=0.32071 MJSWGS=0.32059 MJSWS=0.1 MOBMOD=0 MOIN=15
-+ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nmos_3p3_noia}
-+ NOIB={nmos_3p3_noib} NOIC={nmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NDEP=3e+017 NFACTOR=1 NGATE=6e+019 NJS=1.01 NOFF=2.1 NOIA={nfet_03v3_noia}
++ NOIB={nfet_03v3_noib} NOIC={nfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.70172 PBSWGS=0.74743 PBSWS=0.8062 PCLM=0.21803 PDIBLC1=0.39
 + PDIBLC2=0.000817 PDIBLCB=0.2 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.07 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.6469e+008 PSCBE2=1.638e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
-+ RDSMOD=0 RDSW={nmos_3p3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
++ RDSMOD=0 RDSW={nfet_03v3_rdsw} RDSWMIN=50 RDWMIN=0 RGATEMOD=0 RSH=7 RSWMIN=0
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.0009438 TCJSW=0.00060474 TCJSWG=0.001
-+ TNOIMOD=0 TNOM=25 TOXE={nmos_3p3_tox} TOXM=8e-009 TOXP={nmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={nfet_03v3_tox} TOXM=8e-009 TOXP={nfet_03v3_tox}
 + TOXREF=8e-009 TPB=0.0018129 TPBSW=5e-005 TPBSWG=0.0016872 TRNQSMOD=0
 + TVOFF=0.001 U0=0.040062 UA=-7.8438e-010 UA1=1.6582e-009 UB=3.1655e-018
 + UB1=-2.4138e-018 UC=1.082e-010 UC1=-5.6e-011 UTE=-1.55 VBM=-3 VFBCV=-1
-+ VOFF=-0.12066 VOFFCV=-0.05 VOFFL=0 VSAT=85000 VTH0={nmos_3p3_vth0_15} W0=5e-007
++ VOFF=-0.12066 VOFFCV=-0.05 VOFFL=0 VSAT=85000 VTH0={nfet_03v3_vth0_15} W0=5e-007
 + WINT=1e-008 WL=0 WLN=1 WMAX=0.000100001 WMIN=1e-005 WR=1 WTVOFF=0 WW=0 WWL=0
-+ WWN=1 XJ={nmos_3p3_xj} XL={nmos_3p3_xl} XPART=0 XTIS=3 XW={nmos_3p3_xw}
++ WWN=1 XJ={nfet_03v3_xj} XL={nfet_03v3_xl} XPART=0 XTIS=3 XW={nfet_03v3_xw}
 + LEVEL=14
 
 
@@ -42910,7 +42910,7 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS nplus_u_m1
-.ENDL nmos_3p3_stat
+.ENDL nfet_03v3_stat
 
 *
 *
@@ -42918,8 +42918,8 @@ Rb 1 2
 * 3.3V PMOS statistical Models
 ***************************************************************************************************
 *
-.LIB pmos_3p3_stat
-.SUBCKT pmos_3p3_sab d g s b
+.LIB pfet_03v3_stat
+.SUBCKT pfet_03v3_dss d g s b
 + PARAMS: W=10u L=0.28u PAR=1 S_SAB=0.48u D_SAB=1.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -42943,10 +42943,10 @@ Xr1 d d1 b pplus_u_m1
 
 Xr2 s s1 b pplus_u_m1
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_3p3
+M0 d1 g s1 b pfet_03v3
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_3p3.0 PMOS
+.MODEL pfet_03v3.0 PMOS
 + A0=1.0272635 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19081247
 + ALPHA0=1.1485698e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=39.773597
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -42968,7 +42968,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.6014546e-009 LVTH0=-7.6827273e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-2.7370909e-015 PAGS=-1.2080073e-014 PALPHA0=6.39288e-020
 + PARAMCHK=1 PBETA0=1.1827636e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.35627558 PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -42977,24 +42977,24 @@ M0 d1 g s1 b pmos_3p3
 + PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PU0=-5.2642909e-016
 + PUA=-1.9180342e-022 PUA1=-8.9345454e-023 PUB=1.3557818e-033 PUB1=1.4950473e-031
 + PUC=-4.4743636e-024 PUC1=-1.4057018e-023 PVAG=0 PVOFF=8.3275636e-016
-+ PVTH0=2.3570182e-015 RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20
++ PVTH0=2.3570182e-015 RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20
 + RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483
-+ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009
-+ TOXP={pmos_3p3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
++ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009
++ TOXP={pfet_03v3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
 + TRNQSMOD=0 TVOFF=0.0032 U0=0.0077071688 UA=-2.4381818e-012 UA1=1.1563636e-009
 + UB=6.7035533e-019 UB1=-2.100161e-018 UC=8.6801065e-011 UC1=-2.5418182e-010
 + UTE=-1 VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.094658091 VOFFCV=-0.16 VOFFL=0 VSAT=94000
-+ VTH0={pmos_3p3_vth0_0} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VTH0={pfet_03v3_vth0_0} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=1.1112467e-008 WAGS=-2.3219283e-008 WALPHA0=-1.0325417e-013
 + WBETA0=2.1005299e-007 WINT=-1e-008 WK1=6.7137132e-008 WK2=-2.1522854e-008
 + WKETA=-7.3229236e-009 WKT1=-1.1172031e-008 WL=0 WLN=1 WMAX=5e-007 WMIN=2.2e-007
 + WPCLM=2.9266005e-008 WTVOFF=0 WU0=6.0892675e-010 WUA=3.3100364e-018
 + WUA1=1.7869091e-016 WUB=-4.8420779e-027 WUB1=-1.4002317e-025
 + WUC=-1.3364176e-017 WUC1=4.0843636e-017 WVOFF=-1.6655127e-009
-+ WVTH0=4.2938493e-009 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0
-+ XTIS=3 XW={pmos_3p3_xw}
++ WVTH0=4.2938493e-009 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0
++ XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
-.MODEL pmos_3p3.1 PMOS
+.MODEL pfet_03v3.1 PMOS
 + A0=1.1510659 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19022326
 + ALPHA0=7.5504633e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=42.422959
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -43016,7 +43016,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-3.0738122e-017 LVOFF=1.2890571e-008 LVTH0=8.0902041e-009 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.6645518e-014 PAGS=-3.0616751e-014 PALPHA0=-2.3899709e-018
 + PARAMCHK=1 PBETA0=8.5195102e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.25657102 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -43025,21 +43025,21 @@ M0 d1 g s1 b pmos_3p3
 + PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PU0=-9.8910367e-017
 + PUA=-1.6858315e-022 PUB=9.5112882e-032 PUB1=9.6045061e-032 PUC=-7.4630909e-024
 + PUC1=3.2542237e-024 PVAG=0 PVTH0=1.5205225e-015 RBODYMOD=0 RDSMOD=0
-+ RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007
++ RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007
 + TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25
-+ TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009
++ TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009
 + TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032
 + U0=0.010288147 UA=3.7095469e-010 UA1=1.5e-009 UB=1.0877988e-018
 + UB1=-2.2391388e-018 UC=-1.3265853e-011 UC1=-7.5563755e-011 UTE=-1 VBM=-3 VFB=0
 + VFBCV=-1 VOFF=-0.12364214 VOFFCV=-0.16 VOFFL=0 VSAT=94000
-+ VTH0={pmos_3p3_vth0_1} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VTH0={pfet_03v3_vth0_1} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=3.8929322e-008 WAGS=1.3854074e-008 WALPHA0=4.8045453e-012
 + WBETA0=2.7621551e-007 WINT=-1e-008 WK1=-1.7990939e-008 WK2=-2.5231886e-009
 + WKETA=-2.2043755e-009 WKT1=2.5044049e-008 WL=0 WLN=1 WMAX=5e-007 WMIN=2.2e-007
 + WPCLM=8.5357469e-008 WTVOFF=0 WU0=-2.4611069e-010 WUA=-4.3130498e-017
 + WUB=-1.9235628e-025 WUB1=-3.3103837e-026 WUC=-7.386721e-018 WUC1=6.2211526e-018
-+ WVTH0=5.9668408e-009 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0
-+ XTIS=3 XW={pmos_3p3_xw}
++ WVTH0=5.9668408e-009 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0
++ XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -43194,7 +43194,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.2 PMOS
+.MODEL pfet_03v3.2 PMOS
 + A0=1.2626103 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.15731682
 + ALPHA0=0.0020588939 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.45026
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -43217,7 +43217,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFFCV=-2.1818182e-007 LVTH0=-9.5551948e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=3.4170078e-014 PAGS=-1.4866597e-014 PALPHA0=-2.3332535e-017
 + PARAMCHK=1 PBETA0=-6.7464935e-014 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.32143299 PDIBLC1=0.1484 PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0
@@ -43226,21 +43226,21 @@ M0 d1 g s1 b pmos_3p3
 + PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PU0=-6.5690182e-016
 + PUA=-1.5714468e-022 PUB=-4.1208312e-033 PUB1=-1.7328156e-031
 + PUC=-1.8553586e-023 PUC1=2.5455553e-023 PVAG=0 PVOFF=-1.1894494e-015
-+ PVTH0=4.2667013e-015 RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20
++ PVTH0=4.2667013e-015 RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20
 + RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483
-+ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009
-+ TOXP={pmos_3p3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
++ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009
++ TOXP={pfet_03v3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
 + TRNQSMOD=0 TVOFF=0.0032 U0=0.0087516409 UA=3.9822779e-010 UA1=1.5e-009
 + UB=8.5181617e-019 UB1=-3.0202519e-018 UC=-4.4095525e-011 UC1=-3.5566519e-011
 + UTE=-1 VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.097716396 VOFFCV=0.021818182 VOFFL=0
-+ VSAT=94000 VTH0={pmos_3p3_vth0_2} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VSAT=94000 VTH0={pfet_03v3_vth0_2} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=-3.4170078e-009 WAGS=7.2894545e-010 WALPHA0=2.2256682e-011
 + WBETA0=4.0343221e-007 WINT=-1e-008 WK1=3.0592208e-008 WK2=-1.5055864e-008
 + WKETA=-3.463048e-009 WKT1=-1.0340166e-008 WL=0 WLN=1 WMAX=5e-007 WMIN=2.2e-007
 + WPCLM=4.9757922e-009 WTVOFF=0 WU0=2.1888218e-010 WUA=-5.2662561e-017
 + WUB=-1.0966152e-025 WUB1=1.9133501e-025 WUC=1.8553586e-018 WUC1=-1.2279955e-017
-+ WVOFF=9.9120779e-010 WVTH0=3.6783584e-009 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj}
-+ XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ WVOFF=9.9120779e-010 WVTH0=3.6783584e-009 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj}
++ XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -43436,7 +43436,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.3 PMOS
+.MODEL pfet_03v3.3 PMOS
 + A0=1.2226 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17178714
 + ALPHA0=0.0018173857 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.712143
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -43453,24 +43453,24 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32571714
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
-+ RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7
++ RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932
-+ TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox}
 + TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0
 + TVOFF=0.0032 U0=0.0090519 UA=4.8015429e-010 UA1=1.5e-009 UB=8.449e-019
 + UB1=-2.9869286e-018 UC=-3.4544e-011 UC1=-4.344e-011 UTE=-1 VBM=-3 VFB=0
-+ VFBCV=-1 VOFF=-0.099538429 VOFFCV=0 VOFFL=0 VSAT=94000 VTH0={pmos_3p3_vth0_3}
++ VFBCV=-1 VOFF=-0.099538429 VOFFCV=0 VOFFL=0 VSAT=94000 VTH0={pfet_03v3_vth0_3}
 + VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WAGS=-7.5771429e-010
 + WALPHA0=1.9923429e-011 WBETA0=3.9668571e-007 WINT=-1e-008 WK1=2.6921143e-008
 + WK2=-1.4160343e-008 WKETA=-3.2017886e-009 WKT1=-7.7108571e-009 WL=0 WLN=1
 + WMAX=5e-007 WMIN=2.2e-007 WPCLM=1.2471086e-008 WTVOFF=0 WU0=1.53192e-010
 + WUA=-6.8377029e-017 WUB=-1.100736e-025 WUB1=1.7400686e-025 WUC1=-9.7344e-018
-+ WVOFF=8.7226286e-010 WVTH0=4.1050286e-009 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj}
-+ XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ WVOFF=8.7226286e-010 WVTH0=4.1050286e-009 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj}
++ XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -43682,7 +43682,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.4 PMOS
+.MODEL pfet_03v3.4 PMOS
 + A0=0.66833429 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20459958
 + ALPHA0=1.2079775e-005 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=38.238696
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -43703,8 +43703,8 @@ M0 d1 g s1 b pmos_3p3
 + LUA1=-2.562e-016 LUB=-3.0903909e-025 LUB1=-2.9730909e-026 LUC=1.2453182e-017
 + LUC1=-3.4608e-017 LVTH0=-2.1407273e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-5.5371585e-014 PAGS=6.2401891e-015 PALPHA0=7.4403585e-020 PARAMCHK=1
 + PBETA0=-3.5411055e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3781492
 + PDIBLC1=0.1484 PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
@@ -43712,21 +43712,21 @@ M0 d1 g s1 b pmos_3p3
 + PPCLM=2.9199702e-014 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005
 + PTVOFF=0 PU0=-2.0819854e-016 PUA=-4.0716945e-023 PUA1=1.33224e-022
 + PUB=8.7374182e-032 PUB1=-1.8530247e-031 PUC=-6.5372036e-024 PUC1=3.4396015e-023
-+ PVAG=0 PVTH0=-5.2482182e-016 RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw}
++ PVAG=0 PVTH0=-5.2482182e-016 RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw}
 + RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187
-+ TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox}
-+ TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052
++ TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox}
++ TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052
 + TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032 U0=0.0091928468 UA=-8.0522078e-011
 + UA1=2.0124e-009 UB=1.748897e-018 UB1=-2.8876353e-018 UC=8.6704408e-011
 + UC1=6.432e-012 UTE=-1 VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.097861 VOFFCV=-0.16 VOFFL=0
-+ VSAT=94000 VTH0={pmos_3p3_vth0_4} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VSAT=94000 VTH0={pfet_03v3_vth0_4} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=1.9775566e-007 WAGS=-3.0388584e-008 WALPHA0=-4.121738e-013
 + WBETA0=1.0082017e-006 WINT=-1e-008 WK2=-1.3670166e-008 WKETA=1.2696239e-008
 + WKT1=1.4058139e-008 WL=0 WLN=1 WMAX=1.2e-006 WMIN=5e-007 WPCLM=1.7891728e-008
 + WTVOFF=0 WU0=-1.6362577e-010 WUA=4.3913662e-017 WUA1=-2.66448e-016
 + WUB=-5.6568377e-025 WUB1=2.6946346e-025 WUC=-1.3313914e-017
-+ WUC1=-9.4675549e-017 WVTH0=1.4897689e-008 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj}
-+ XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ WUC1=-9.4675549e-017 WVTH0=1.4897689e-008 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj}
++ XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -43889,7 +43889,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.5 PMOS
+.MODEL pfet_03v3.5 PMOS
 + A0=1.3454526 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.19226653
 + ALPHA0=0.000123026 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.366204
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -43911,7 +43911,7 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.8185143e-017 LVOFF=1.2890571e-008 LVTH0=-3.242449e-010 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=7.4582136e-014 PAGS=-1.5349891e-014 PALPHA0=9.8215995e-018
 + PARAMCHK=1 PBETA0=2.571262e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.55246506 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -43920,21 +43920,21 @@ M0 d1 g s1 b pmos_3p3
 + PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PU0=-3.0761926e-016
 + PUA=-2.4019161e-023 PUB=-5.1075673e-032 PUB1=-2.6761322e-031
 + PUC=-3.9712404e-024 PUC1=-2.2185874e-023 PVAG=0 PVTH0=5.8960359e-015 RBODYMOD=0
-+ RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007
++ RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007
 + SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0
-+ TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009
++ TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009
 + TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032
 + U0=0.0097471347 UA=2.6778433e-010 UA1=1.5e-009 UB=1.2732368e-018
 + UB1=-3.1375788e-018 UC=8.0016841e-012 UC1=-9.9154286e-011 UTE=-1 VBM=-3 VFB=0
 + VFBCV=-1 VOFF=-0.12364214 VOFFCV=-0.16 VOFFL=0 VSAT=94000
-+ VTH0={pmos_3p3_vth0_5} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VTH0={pfet_03v3_vth0_5} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=-6.215178e-008 WAGS=1.2791576e-008 WALPHA0=-1.9906566e-011
 + WBETA0=-2.1427184e-007 WINT=-1e-008 WK2=1.6697667e-009 WKETA=-3.9902465e-009
 + WKT1=1.2888678e-008 WL=0 WLN=1 WMAX=1.2e-006 WMIN=5e-007 WPCLM=-6.8507432e-008
 + WTVOFF=0 WU0=3.5215673e-011 WUA=1.0518093e-017 WUB=-2.8878406e-025
 + WUB1=4.3408496e-025 WUC=-1.844584e-017 WUC1=1.8488229e-017 WVTH0=2.0559739e-009
-+ WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0 XTIS=3
-+ XW={pmos_3p3_xw}
++ WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0 XTIS=3
++ XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -44130,7 +44130,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.6 PMOS
+.MODEL pfet_03v3.6 PMOS
 + A0=1.1189871 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16561084
 + ALPHA0=0.002173683 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.354662
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -44153,8 +44153,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=-4.9745455e-017 LVOFF=-2.0507727e-008 LVOFFCV=-2.1818182e-007
 + LVTH0=-1.3737662e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1
 + PA0=-8.5520416e-014 PAGS=4.3007377e-015 PALPHA0=3.0854085e-017 PARAMCHK=1
 + PBETA0=-5.4377143e-013 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3288581
 + PDIBLC1=0.1484 PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0
@@ -44162,21 +44162,21 @@ M0 d1 g s1 b pmos_3p3
 + PPCLM=-1.1147314e-014 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005
 + PTVOFF=0 PU0=8.3913818e-017 PUA=5.487148e-023 PUB=-6.986227e-032
 + PUB1=2.878281e-031 PUC=-9.1205299e-026 PUC1=1.0381091e-023 PVAG=0
-+ PVTH0=1.2358442e-017 RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20
++ PVTH0=1.2358442e-017 RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20
 + RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483
-+ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009
-+ TOXP={pmos_3p3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
++ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009
++ TOXP={pfet_03v3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
 + TRNQSMOD=0 TVOFF=0.0032 U0=0.0097323026 UA=4.0315384e-010 UA1=1.5e-009
 + UB=1.1661759e-018 UB1=-2.5969484e-018 UC=1.1632475e-012 UC1=-4.2545455e-011
 + UTE=-1 VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.095810227 VOFFCV=0.021818182 VOFFL=0
-+ VSAT=94000 VTH0={pmos_3p3_vth0_6} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VSAT=94000 VTH0={pfet_03v3_vth0_6} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=7.1267013e-008 WAGS=-3.583948e-009 WALPHA0=-3.7433637e-011
 + WBETA0=4.5314286e-007 WINT=-1e-008 WK2=-6.4973683e-009 WKT1=2.5666423e-008
 + WKT2=2.0185455e-009 WL=0 WLN=1 WMAX=1.2e-006 WMIN=5e-007 WPCLM=1.1147314e-009
 + WTVOFF=0 WU0=-2.910619e-010 WUA=-5.5224108e-017 WUB=-2.7312856e-025
 + WUB1=-2.878281e-026 WUC=-2.1679203e-017 WUC1=-8.6509091e-018
-+ WVTH0=6.9590384e-009 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0
-+ XTIS=3 XW={pmos_3p3_xw}
++ WVTH0=6.9590384e-009 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0
++ XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -44370,7 +44370,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.7 PMOS
+.MODEL pfet_03v3.7 PMOS
 + A0=1.1019943 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17639514
 + ALPHA0=0.0019217543 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.708143
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -44387,23 +44387,23 @@ M0 d1 g s1 b pmos_3p3
 + LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1
 + MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
-+ RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7
++ RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932
-+ TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox}
 + TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0
 + TVOFF=0.0032 U0=0.0098900971 UA=4.44308e-010 UA1=1.5e-009 UB=1.1719023e-018
 + UB1=-2.6523e-018 UC=7.1643143e-012 UC1=-4.752e-011 UTE=-1 VBM=-3 VFB=0 VFBCV=-1
-+ VOFF=-0.097861 VOFFCV=0 VOFFL=0 VSAT=94000 VTH0={pmos_3p3_vth0_7} VTSS=10
++ VOFF=-0.097861 VOFFCV=0 VOFFL=0 VSAT=94000 VTH0={pfet_03v3_vth0_7} VTSS=10
 + VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WA0=6.2714971e-008 WAGS=-3.1538743e-009
 + WALPHA0=-3.4348229e-011 WBETA0=3.9876571e-007 WINT=-1e-008 WK2=-6.172712e-009
 + WKT1=2.3527177e-008 WKT2=1.77632e-009 WL=0 WLN=1 WMAX=1.2e-006 WMIN=5e-007
 + WTVOFF=0 WU0=-2.8267051e-010 WUA=-4.973696e-017 WUB=-2.8011479e-025
 + WUC=-2.1688323e-017 WUC1=-7.6128e-018 WVTH0=6.9602743e-009 WW=0 WWL=0 WWN=1
-+ XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -44613,7 +44613,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.8 PMOS
+.MODEL pfet_03v3.8 PMOS
 + A0=0.8879706 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.3341873
 + ALPHA0=9.723125e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.805966
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -44635,8 +44635,8 @@ M0 d1 g s1 b pmos_3p3
 + LUB1=-1.2857843e-025 LUC=-7.439668e-018 LUC1=8.8928926e-019
 + LVTH0=-8.7733719e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=-1.5381528e-015 PAGS=9.42428e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=-1.5381528e-015 PAGS=9.42428e-014
 + PALPHA0=-8.3139811e-019 PARAMCHK=1 PBETA0=-7.708444e-013 PBS=0.69939
 + PBSWGS=0.65 PBSWS=0.8022 PCLM=0.32482036 PDIBLC1=0.1484 PDIBLC2=0.00073695
 + PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PK2=-2.2709854e-015
@@ -44645,21 +44645,21 @@ M0 d1 g s1 b pmos_3p3
 + PTVOFF=0 PU0=-1.493953e-016 PUA=1.0254352e-022 PUA1=1.078475e-023
 + PUB=-3.2981002e-031 PUB1=-6.4708497e-032 PUC=1.7732073e-023
 + PUC1=-8.9106783e-024 PVAG=0 PVTH0=7.5670046e-015 RBODYMOD=0 RDSMOD=0
-+ RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007
++ RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007
 + TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25
-+ TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009
++ TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009
 + TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032
 + U0=0.011352976 UA=3.4788822e-010 UA1=1.8116799e-009 UB=9.2772209e-019
 + UB1=-2.5843988e-018 UC=1.3375779e-010 UC1=-8.5778578e-011 UTE=-1 VBM=-3 VFB=0
-+ VFBCV=-1 VOFF=-0.097861 VOFFCV=-0.16 VOFFL=0 VSAT=94000 VTH0={pmos_3p3_vth0_8}
++ VFBCV=-1 VOFF=-0.097861 VOFFCV=-0.16 VOFFL=0 VSAT=94000 VTH0={pfet_03v3_vth0_8}
 + VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WA0=-7.0200638e-008
 + WAGS=-1.884856e-007 WALPHA0=2.4629388e-012 WBETA0=1.5361323e-006 WINT=-1e-008
 + WK2=4.5419708e-009 WKETA=-6.803611e-009 WKT1=-3.0216242e-008
 + WKT2=9.4871699e-009 WL=0 WLN=1 WMAX=1e-005 WMIN=1.2e-006 WPCLM=8.2952909e-008
 + WTVOFF=0 WU0=-2.7989835e-009 WUA=-4.7874691e-016 WUA1=-2.1569499e-017
 + WUB=4.3614967e-025 WUB1=-1.0048507e-025 WUC=-7.0719038e-017 WUC1=1.7821357e-017
-+ WVTH0=4.2305517e-009 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0
-+ XTIS=3 XW={pmos_3p3_xw}
++ WVTH0=4.2305517e-009 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0
++ XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -44818,7 +44818,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.9 PMOS
+.MODEL pfet_03v3.9 PMOS
 + A0=1.1782327 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20788505
 + ALPHA0=0.00011108151 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.187318
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -44841,7 +44841,7 @@ M0 d1 g s1 b pmos_3p3
 + LVOFF=-1.787102e-009 LVTH0=-7.1445584e-009 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PA0=-1.0756678e-013 PAGS=3.1315103e-015 PALPHA0=3.0672131e-018
 + PARAMCHK=1 PBETA0=-4.7627532e-015 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.37778426 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0 PDITS=0 PDITSD=0
@@ -44850,21 +44850,21 @@ M0 d1 g s1 b pmos_3p3
 + PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PU0=-1.3347616e-015
 + PUA=-1.0668567e-022 PUB=-1.570756e-031 PUB1=8.0252392e-032 PUC=-3.0218479e-023
 + PUC1=3.0005345e-023 PVAG=0 PVOFF=1.7906761e-014 PVTH0=1.4216818e-014 RBODYMOD=0
-+ RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007
++ RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007
 + SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0
-+ TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009
++ TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009
 + TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032
 + U0=0.010127025 UA=3.2582253e-010 UA1=1.5e-009 UB=9.6220002e-019
 + UB1=-2.4617658e-018 UC=-2.7758895e-011 UC1=-3.4810909e-011 UTE=-1 VBM=-3 VFB=0
 + VFBCV=-1 VOFF=-0.094286796 VOFFCV=-0.16 VOFFL=0 VSAT=94000
-+ VTH0={pmos_3p3_vth0_9} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VTH0={pfet_03v3_vth0_9} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=1.4185662e-007 WAGS=-6.2630205e-009 WALPHA0=-5.3342836e-012
 + WBETA0=3.968961e-009 WINT=-1e-008 WK2=6.1891978e-009 WKETA=2.1382778e-009
 + WKT1=3.6107623e-008 WKT2=-2.981682e-009 WL=0 WLN=1 WMAX=1e-005 WMIN=1.2e-006
 + WPCLM=1.4460314e-007 WTVOFF=0 WU0=-4.282509e-010 WUA=-6.0288518e-017
 + WUB=9.0680837e-026 WUB1=-3.9040685e-025 WUC=2.5182066e-017 WUC1=-6.0010691e-017
-+ WVOFF=-3.5813523e-008 WVTH0=-9.069076e-009 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj}
-+ XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ WVOFF=-3.5813523e-008 WVTH0=-9.069076e-009 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj}
++ XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -45062,7 +45062,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.10 PMOS
+.MODEL pfet_03v3.10 PMOS
 + A0=1.1832393 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16685819
 + ALPHA0=0.0021426891 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.161948
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -45085,8 +45085,8 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=1.3542397e-017 LVOFF=2.8431167e-009 LVOFFCV=-2.1818182e-007
 + LVTH0=-4.4690083e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PA0=7.1205867e-014
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=1.9454546 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PA0=7.1205867e-014
 + PAGS=1.7427347e-015 PALPHA0=-3.7885537e-018 PARAMCHK=1 PBETA0=-8.2590471e-013
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.34313423 PDIBLC1=0.1484
 + PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0
@@ -45094,21 +45094,21 @@ M0 d1 g s1 b pmos_3p3
 + PPCLM=1.6302147e-013 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005
 + PTVOFF=0 PU0=4.0272326e-016 PUA=2.7440495e-022 PUA1=-1.5229986e-022
 + PUB1=-4.4117708e-031 PUC1=-6.6830088e-023 PVAG=0 PVOFF=-2.848803e-014
-+ PVTH0=3.7885537e-015 RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20
++ PVTH0=3.7885537e-015 RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20
 + RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483
-+ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009
-+ TOXP={pmos_3p3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
++ TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009
++ TOXP={pfet_03v3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744
 + TRNQSMOD=0 TVOFF=0.0032 U0=0.011031559 UA=6.676128e-010 UA1=1.39597e-009
 + UB=9.7526352e-019 UB1=-2.656703e-018 UC=-1.6606591e-011 UC1=-6.6591694e-011
 + UTE=-1 VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.098145312 VOFFCV=0.021818182 VOFFL=0
-+ VSAT=94000 VTH0={pmos_3p3_vth0_10} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VSAT=94000 VTH0={pfet_03v3_vth0_10} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WA0=-7.1205867e-009 WAGS=-5.1057076e-009 WALPHA0=3.7885537e-013
 + WBETA0=6.8825393e-007 WINT=-1e-008 WK2=3.9592281e-009 WKT1=-2.4401443e-008
 + WKT2=-3.0939855e-009 WL=0 WLN=1 WMAX=1e-005 WMIN=1.2e-006 WPCLM=-1.6302147e-008
 + WTVOFF=0 WU0=-1.8761549e-009 WUA=-3.7786403e-016 WUA1=1.2691655e-016
 + WUB=-4.0215498e-026 WUB1=4.4117708e-026 WUC1=2.0685503e-017 WVOFF=2.848803e-009
-+ WVTH0=-3.7885537e-010 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl}
-+ XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ WVTH0=-3.7885537e-010 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl}
++ XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -45307,7 +45307,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.11 PMOS
+.MODEL pfet_03v3.11 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17785216
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.538555 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4e-011
@@ -45324,23 +45324,23 @@ M0 d1 g s1 b pmos_3p3
 + LMIN=1e-005 LPE0=3.2493e-008 LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1
 + MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017
 + NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2
-+ NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020
++ NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020
 + NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.3497
 + PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1
 + PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0
-+ RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7
++ RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7
 + SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932
-+ TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox}
++ TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox}
 + TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0
 + TVOFF=0.0032 U0=0.011163222 UA=6.9077241e-010 UA1=1.4084536e-009
 + UB=9.7526352e-019 UB1=-2.6523e-018 UC=-1.0613e-011 UC1=-6.5237455e-011 UTE=-1
 + VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.097861 VOFFCV=0 VOFFL=0 VSAT=94000
-+ VTH0={pmos_3p3_vth0_11} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
++ VTH0={pfet_03v3_vth0_11} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006
 + WAGS=-4.9314341e-009 WBETA0=6.0566345e-007 WINT=-1e-008 WK2=3.9173646e-009
 + WKT1=-2.0031346e-008 WKT2=-2.7227073e-009 WL=0 WLN=1 WMAX=1e-005 WMIN=1.2e-006
 + WTVOFF=0 WU0=-1.8358826e-009 WUA=-3.5042354e-016 WUA1=1.1168656e-016
-+ WUB=-4.0215498e-026 WUC1=1.4002494e-017 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj}
-+ XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ WUB=-4.0215498e-026 WUC1=1.4002494e-017 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj}
++ XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -45551,7 +45551,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.12 PMOS
+.MODEL pfet_03v3.12 PMOS
 + A0=0.88096455 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.31537636
 + ALPHA0=9.9689273e-006 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=37.959273
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -45572,21 +45572,21 @@ M0 d1 g s1 b pmos_3p3
 + LU0=1.7741818e-009 LUA=6.4094546e-016 LUA1=-1.5476364e-016 LUB1=-1.3503636e-025
 + LUC=-5.67e-018 LVTH0=-8.0181818e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084
 + MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8
-+ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia}
-+ NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
++ NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia}
++ NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1
 + PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022 PCLM=0.33309909 PDIBLC1=0.1484
 + PDIBLC2=0.00073695 PDIBLCB=0 PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0
 + PRWB=0 PRWG=0 PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0
-+ RDSMOD=0 RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007
++ RDSMOD=0 RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007
 + SBREF=4.4e-007 TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0
-+ TNOM=25 TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009
++ TNOM=25 TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009
 + TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032
 + U0=0.011073636 UA=3.0010909e-010 UA1=1.8095273e-009 UB=9.7125e-019
 + UB1=-2.5944273e-018 UC=1.267e-010 UC1=-8.4e-011 UTE=-1 VBM=-3 VFB=0 VFBCV=-1
-+ VOFF=-0.097861 VOFFCV=-0.16 VOFFL=0 VSAT=94000 VTH0={pmos_3p3_vth0_12} VTSS=10
++ VOFF=-0.097861 VOFFCV=-0.16 VOFFL=0 VSAT=94000 VTH0={pfet_03v3_vth0_12} VTSS=10
 + VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WINT=-1e-008 WL=0 WLN=1 WMAX=0.000100001
-+ WMIN=1e-005 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0
-+ XTIS=3 XW={pmos_3p3_xw}
++ WMIN=1e-005 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0
++ XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -45753,7 +45753,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.13 PMOS
+.MODEL pfet_03v3.13 PMOS
 + A0=1.19239 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.20726
 + ALPHA0=0.00011054914 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.187714
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -45774,21 +45774,21 @@ M0 d1 g s1 b pmos_3p3
 + LUA=6.3109714e-016 LUB1=-1.8188571e-025 LUC=7.0302857e-017 LUC1=-2.16e-017
 + LVTH0=-5.7257143e-009 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2.4 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.39221571 PDIBLC1=0.1484 PDIBLC2=0.00024628714 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0
 + PSCBE1=6.7448e+008 PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0
-+ RDSW={pmos_3p3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007
++ RDSW={pfet_03v3_rdsw} RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007
 + TCJ=0.00099187 TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25
-+ TOXE={pmos_3p3_tox} TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009
++ TOXE={pfet_03v3_tox} TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009
 + TPB=0.0016906 TPBSW=0.0052 TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032
 + U0=0.010084286 UA=3.1980571e-010 UA1=1.5e-009 UB=9.7125e-019
 + UB1=-2.5007286e-018 UC=-2.5245714e-011 UC1=-4.08e-011 UTE=-1 VBM=-3 VFB=0
-+ VFBCV=-1 VOFF=-0.097861 VOFFCV=-0.16 VOFFL=0 VSAT=94000 VTH0={pmos_3p3_vth0_13}
++ VFBCV=-1 VOFF=-0.097861 VOFFCV=-0.16 VOFFL=0 VSAT=94000 VTH0={pfet_03v3_vth0_13}
 + VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WINT=-1e-008 WL=0 WLN=1
-+ WMAX=0.000100001 WMIN=1e-005 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj}
-+ XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ WMAX=0.000100001 WMIN=1e-005 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj}
++ XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -45961,7 +45961,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.14 PMOS
+.MODEL pfet_03v3.14 PMOS
 + A0=1.1825286 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.16634864
 + ALPHA0=0.002142727 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=44.230636
 + BGIDL=1.3902e+009 BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0
@@ -45983,21 +45983,21 @@ M0 d1 g s1 b pmos_3p3
 + LUC1=6.8727273e-018 LVOFFCV=-2.1818182e-007 LVTH0=-4.0909091e-009 LW=0 LWL=0
 + LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964 MJSWS=0.05 MOBMOD=0 MOIN=15
 + NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1 NJTS=20 NJTSSW=20 NJTSSWG=20
-+ NOFF=1.9454546 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib} NOIC={pmos_3p3_noic}
++ NOFF=1.9454546 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib} NOIC={pfet_03v3_noic}
 + NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65 PBSWS=0.8022
 + PCLM=0.34150727 PDIBLC1=0.1484 PDIBLC2=7.8434545e-005 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
-+ PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw}
++ PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw}
 + RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187
-+ TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox}
-+ TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052
++ TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox}
++ TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052
 + TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032 U0=0.010844318 UA=6.2990182e-010
 + UA1=1.4086364e-009 UB=9.7125e-019 UB1=-2.6523e-018 UC=-1.6606591e-011
 + UC1=-6.4527273e-011 UTE=-1 VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.097861
-+ VOFFCV=0.021818182 VOFFL=0 VSAT=94000 VTH0={pmos_3p3_vth0_14} VTSS=10
++ VOFFCV=0.021818182 VOFFL=0 VSAT=94000 VTH0={pfet_03v3_vth0_14} VTSS=10
 + VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WINT=-1e-008 WL=0 WLN=1 WMAX=0.000100001
-+ WMIN=1e-005 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0
-+ XTIS=3 XW={pmos_3p3_xw}
++ WMIN=1e-005 WTVOFF=0 WW=0 WWL=0 WWN=1 XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0
++ XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -46170,7 +46170,7 @@ M0 d1 g s1 b pmos_3p3
 
 
 
-.MODEL pmos_3p3.15 PMOS
+.MODEL pfet_03v3.15 PMOS
 + A0=1.1534 A1=0 A2=0.99 ACDE=1 ACNQSMOD=0 AGIDL=1.5908e-011 AGS=0.17736
 + ALPHA0=0.0018936 ALPHA1=0 AT=12000 B0=0 B1=0 BETA0=43.599 BGIDL=1.3902e+009
 + BINUNIT=2 CAPMOD=2 CDSC=0.00024 CDSCB=0 CDSCD=0 CF=0 CGBO=1e-013 CGDL=4e-011
@@ -46186,20 +46186,20 @@ M0 d1 g s1 b pmos_3p3
 + KVSAT=0 KVTH0=0 LINT=0 LL=0 LLN=1 LMAX=5.0001e-005 LMIN=1e-005 LPE0=3.2493e-008
 + LPEB=0 LTVOFF=0 LW=0 LWL=0 LWN=1 MINV=-0.1 MJS=0.32084 MJSWGS=0.21964
 + MJSWS=0.05 MOBMOD=0 MOIN=15 NDEP=5.6e+017 NFACTOR=0.8 NGATE=6e+019 NJS=1
-+ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pmos_3p3_noia} NOIB={pmos_3p3_noib}
-+ NOIC={pmos_3p3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
++ NJTS=20 NJTSSW=20 NJTSSWG=20 NOFF=2 NOIA={pfet_03v3_noia} NOIB={pfet_03v3_noib}
++ NOIC={pfet_03v3_noic} NSD=1e+020 NTNOI=1 PARAMCHK=1 PBS=0.69939 PBSWGS=0.65
 + PBSWS=0.8022 PCLM=0.3497 PDIBLC1=0.1484 PDIBLC2=0.00012311 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0 PRT=0 PRWB=0 PRWG=0 PSCBE1=6.7448e+008
-+ PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW={pmos_3p3_rdsw}
++ PSCBE2=1e-005 PTVOFF=0 PVAG=0 RBODYMOD=0 RDSMOD=0 RDSW={pfet_03v3_rdsw}
 + RDSWMIN=20 RGATEMOD=0 RSH=7 SAREF=4.4e-007 SBREF=4.4e-007 TCJ=0.00099187
-+ TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pmos_3p3_tox}
-+ TOXM=7.9e-009 TOXP={pmos_3p3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052
++ TCJSW=0.00063483 TCJSWG=0.000932 TNOIMOD=0 TNOM=25 TOXE={pfet_03v3_tox}
++ TOXM=7.9e-009 TOXP={pfet_03v3_tox} TOXREF=7.9e-009 TPB=0.0016906 TPBSW=0.0052
 + TPBSWG=0.000744 TRNQSMOD=0 TVOFF=0.0032 U0=0.01098 UA=6.558e-010
 + UA1=1.4196e-009 UB=9.7125e-019 UB1=-2.6523e-018 UC=-1.0613e-011 UC1=-6.384e-011
 + UTE=-1 VBM=-3 VFB=0 VFBCV=-1 VOFF=-0.097861 VOFFCV=0 VOFFL=0 VSAT=94000
-+ VTH0={pmos_3p3_vth0_15} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WINT=-1e-008
++ VTH0={pfet_03v3_vth0_15} VTSS=10 VTSSWGS=10 VTSSWS=10 W0=2.5e-006 WINT=-1e-008
 + WL=0 WLN=1 WMAX=0.000100001 WMIN=1e-005 WTVOFF=0 WW=0 WWL=0 WWN=1
-+ XJ={pmos_3p3_xj} XL={pmos_3p3_xl} XPART=0 XTIS=3 XW={pmos_3p3_xw}
++ XJ={pfet_03v3_xj} XL={pfet_03v3_xl} XPART=0 XTIS=3 XW={pfet_03v3_xw}
 + LEVEL=14
 
 
@@ -46613,23 +46613,23 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m1
-.ENDL pmos_3p3_stat
+.ENDL pfet_03v3_stat
 
 *
 ***************************************************************************************************
 * 6V native NMOS statistical Models
 ***************************************************************************************************
 *
-.LIB nmos_6p0_nat_stat
-*.lib nmos_6p0_nat_t
+.LIB nfet_06v0_nvt_stat
+*.lib nfet_06v0_nvt_t
 
-.SUBCKT nmos_6p0_nat d g s b
+.SUBCKT nfet_06v0_nvt d g s b
 + PARAMS: W=1e-5 L=1.8e-6 AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0 PAR=1 DTEMP=0 SA=0 SB=0 NF=1
 + SD=0 M=1
-M0 d g s b nmos_6p0_nat
+M0 d g s b nfet_06v0_nvt
 + AD={ad} AS={as} L={l} NRD={nrd} NRS={nrs} PD={pd} PS={ps} W={w}
-.ENDS nmos_6p0_nat
-.MODEL nmos_6p0_nat.0 NMOS
+.ENDS nfet_06v0_nvt
+.MODEL nfet_06v0_nvt.0 NMOS
 + A0=0.88 A1=0 A2=0.47 ACDE=0.3 ACNQSMOD=0 AGIDL=2e-010 AGS=0.72 AIGBACC=0.43
 + AIGBINV=0.35 AIGC=0.43 AIGSD=0.43 ALPHA0=1.36e-008 ALPHA1=1e-005 AT=80000
 + B0=3.5e-007 B1=0 BETA0=15 BGIDL=2.3e+009 BIGBACC=0.054 BIGBINV=0.03 BIGC=0.054
@@ -46650,8 +46650,8 @@ M0 d g s b nmos_6p0_nat
 + LUTE=-0.26 LVTH0=-0.088 LW=0 LWC=0 LWL=0 LWLC=0 LWN=1 MINV=-0.5 MJS=0.296
 + MJSWGS=0.40313 MJSWS=0.01 MOBMOD=0 MOIN=15 NDEP=1.7e+017 NFACTOR=0.40241
 + NGATE=1e+020 NGCON=1 NIGBACC=1 NIGBINV=3 NIGC=1 NJS=1.0541 NJTS=20 NJTSSW=20
-+ NJTSSWG=20 NOFF=1.5 NOIA={nmos_6p0_nat_noia} NOIB={nmos_6p0_nat_noib}
-+ NOIC={nmos_6p0_nat_noic} NSD=1e+020 NTNOI=1 NTOX=1 PARAMCHK=1 PAT=-10000
++ NJTSSWG=20 NOFF=1.5 NOIA={nfet_06v0_nvt_noia} NOIB={nfet_06v0_nvt_noib}
++ NOIC={nfet_06v0_nvt_noic} NSD=1e+020 NTNOI=1 NTOX=1 PARAMCHK=1 PAT=-10000
 + PBS=0.606 PBSWGS=0.861 PBSWS=0.48 PCLM=3 PDIBLC1=1.41 PDIBLC2=1e-005 PDIBLCB=0
 + PDITS=0 PDITSD=0 PDITSL=0 PERMOD=1 PHIN=0.5 PIGCD=1 PKU0=0 PKVTH0=0 POXEDGE=1
 + PRT=0 PRWB=0 PRWG=1 PSCBE1=5e+009 PSCBE2=5e-006 PVAG=1 PVSAT=23500 RBDB=50
@@ -46659,20 +46659,20 @@ M0 d g s b nmos_6p0_nat
 + RBPBY0=100 RBPBYL=0 RBPBYNF=0 RBPBYW=0 RBPD=50 RBPD0=50 RBPDL=0 RBPDNF=0
 + RBPDW=0 RBPS=50 RBPS0=50 RBPSL=0 RBPSNF=0 RBPSW=0 RBSB=50 RBSBX0=100 RBSBY0=100
 + RBSDBXL=0 RBSDBXNF=0 RBSDBXW=0 RBSDBYL=0 RBSDBYNF=0 RBSDBYW=0 RDSMOD=0
-+ RDSW={nmos_6p0_nat_rdsw} RDSWMIN=0 RDW=100 RDWMIN=0 RGATEMOD=0 RSH=7 RSHG=0.1
++ RDSW={nfet_06v0_nvt_rdsw} RDSWMIN=0 RDW=100 RDWMIN=0 RGATEMOD=0 RSH=7 RSHG=0.1
 + RSW=100 RSWMIN=0 SAREF=1e-006 SBREF=1e-006 SCREF=1e-006 STETA0=0 STK2=0
 + TCJ=0.000825 TCJSW=0.0018 TCJSWG=0.001595 TEMPMOD=0 TKU0=0 TNJTS=0 TNJTSSW=0
-+ TNJTSSWG=0 TNOIMOD=0 TNOM=25 TOXE={nmos_6p0_nat_tox} TOXM=1.52e-008
-+ TOXP='8e-10+nmos_6p0_nat_tox' TOXREF=1.52e-008 TPB=0.00146 TPBSW=0.00313
++ TNJTSSWG=0 TNOIMOD=0 TNOM=25 TOXE={nfet_06v0_nvt_tox} TOXM=1.52e-008
++ TOXP='8e-10+nfet_06v0_nvt_tox' TOXREF=1.52e-008 TPB=0.00146 TPBSW=0.00313
 + TPBSWG=0.0016588 TRNQSMOD=0 TVFBSDOFF=0 TVOFF=0 U0=0.070102 UA=2.278e-009
 + UA1=1e-009 UB=3.97e-019 UB1=-1e-018 UC=2.625e-012 UC1=-5.6e-011 UD1=0 UP=0
 + UTE=-1.5 VBM=-3 VFBCV=-1 VFBSDOFF=0 VOFF=-0.06 VOFFCV=0 VOFFL=0 VSAT=106700
-+ VTH0={nmos_6p0_nat_vth0} VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
++ VTH0={nfet_06v0_nvt_vth0} VTL=200000 VTSD=10 VTSS=10 VTSSWD=10 VTSSWGD=10
 + VTSSWGS=10 VTSSWS=10 W0=1e-010 WEB=0 WEC=0 WINT=1e-009 WKU0=0 WKVTH0=0 WL=0
 + WLC=0 WLN=1 WLOD=0 WLODKU0=0 WLODVTH=0 WMAX=100.01e-6 WMIN=0.8e-6 WPEMOD=0 WR=1
-+ WW=0 WWC=0 WWL=0 WWLC=0 WWN=1 XGL=0 XGW=0 XJ={nmos_6p0_nat_xj} XJBVD=1 XJBVS=1
-+ XL={nmos_6p0_nat_xl} XN=3 XPART=0 XRCRG1=12 XRCRG2=1 XTIS=3 XTSD=0.02 XTSS=0.02
-+ XTSSWD=0.02 XTSSWGD=0.02 XTSSWGS=0.02 XTSSWS=0.02 XW={nmos_6p0_nat_xw}
++ WW=0 WWC=0 WWL=0 WWLC=0 WWN=1 XGL=0 XGW=0 XJ={nfet_06v0_nvt_xj} XJBVD=1 XJBVS=1
++ XL={nfet_06v0_nvt_xl} XN=3 XPART=0 XRCRG1=12 XRCRG2=1 XTIS=3 XTSD=0.02 XTSS=0.02
++ XTSSWD=0.02 XTSSWGD=0.02 XTSSWGS=0.02 XTSSWS=0.02 XW={nfet_06v0_nvt_xw}
 + LEVEL=14
 **************************************************************
 *               MODEL FLAG PARAMETERS
@@ -46760,7 +46760,7 @@ M0 d g s b nmos_6p0_nat
 
 *               STRESS PARAMETERS
 **************************************************************
-.ENDL nmos_6p0_nat_stat
+.ENDL nfet_06v0_nvt_stat
 
 
 
@@ -46776,8 +46776,8 @@ M0 d g s b nmos_6p0_nat
 * 6V PMOS statistical Models
 ***************************************************************************************************
 *
-.LIB pmos_6p0_stat
-.SUBCKT pmos_6p0_sab d g s b
+.LIB pfet_06v0_stat
+.SUBCKT pfet_06v0_dss d g s b
 + PARAMS: W=10u L=0.5u PAR=1 S_SAB=0.28u D_SAB=2.78u AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0
 + DTEMP=0 NF=1 SA=0 SB=0 SD=0 M=1
 .PARAM
@@ -46801,10 +46801,10 @@ Xr1 d d1 b pplus_u_m2
 
 Xr2 s s1 b pplus_u_m2
 + PARAMS: WR='w' LR='(s_sab==0) ? 1e-15 : s_sab' DTEMP={dtemp}
-M0 d1 g s1 b pmos_6p0
+M0 d1 g s1 b pfet_06v0
 + AD={ad} AS={as} L='l' NRD={nrd} NRS={nrs} PD={pd} PS={ps} W='w'
 .ENDS
-.MODEL pmos_6p0.0 PMOS
+.MODEL pfet_06v0.0 PMOS
 + A0=0.84 A1=0 A2=1 ACDE=0.7 ACNQSMOD=0 AGS=0.059 ALPHA0=9.6E-7 ALPHA1=51.5
 + AT=-2.18E4 B0=2.625E-8 B1=0 BETA0=50.8 BINUNIT=1 BVD=10.5 BVS=10.5 CAPMOD=2
 + CDSC=2.4E-4 CDSCB=0 CDSCD=0 CGBO=1E-13 CGDL=5.25E-11 CGDO=7.71E-11
@@ -46821,23 +46821,23 @@ M0 d1 g s1 b pmos_6p0
 + LUB1=1.939773E-19 LUC=8.691408E-11 LUC1=-1.067674E-10 LUTE=-0.152467 LW=0
 + LWL=-4.76E-21 LWN=1 MINV=0 MJD=0.32713 MJS=0.32713 MJSWD=0.056777
 + MJSWGD=0.50996 MJSWGS=0.50996 MJSWS=0.056777 MOBMOD=0 MOIN=15 NDEP=1.7E17
-+ NFACTOR=1 NGATE=3.6E19 NJD=1 NJS=1 NOFF=1 NOIA={pmos_6p0_noia}
-+ NOIB={pmos_6p0_noib} NOIC={pmos_6p0_noic} NSD=6E16 PARAMCHK=1 PAT=-6.1E3
++ NFACTOR=1 NGATE=3.6E19 NJD=1 NJS=1 NOFF=1 NOIA={pfet_06v0_noia}
++ NOIB={pfet_06v0_noib} NOIC={pfet_06v0_noic} NSD=6E16 PARAMCHK=1 PAT=-6.1E3
 + PBD=0.76836 PBETA0=0.14 PBS=0.76836 PBSWD=0.5 PBSWGD=1.2295 PBSWGS=1.2295
 + PBSWS=0.5 PCLM=0.42 PDIBLC1=0.14 PDIBLC2=1E-5 PDIBLCB=0 PDITS=0.01 PDITSD=0
 + PDITSL=0 PERMOD=1 PETAB=-0.012128 PHIN=0 PKT1=2.2E-3 PPCLM=0.071 PPRWB=-0.052
 + PRDSW=-120 PRT=454 PRWB=0.569552 PRWG=0.0432 PSCBE1=5.088E8 PSCBE2=1E-8
 + PUA1=-3.823641E-10 PUB1=7.291324E-19 PUC=-1.501336E-11 PUC1=1.8536E-11 PVAG=1.5
-+ PVTH0=7.6E-3 RBODYMOD=0 RDSMOD=0 RDSW={pmos_6p0_rdsw} RDSWMIN=100 RSH=7
++ PVTH0=7.6E-3 RBODYMOD=0 RDSMOD=0 RDSW={pfet_06v0_rdsw} RDSWMIN=100 RSH=7
 + RSHG=0.1 TCJ=0.001 TCJSW=0.00071888 TCJSWG=0.0009411 TEMPMOD=0 TNOIMOD=0
-+ TNOM=25 TOXE={pmos_6p0_tox} TPB=0.0019314 TPBSW=0.0017642 TPBSWG=0.0016588
++ TNOM=25 TOXE={pfet_06v0_tox} TPB=0.0019314 TPBSW=0.0017642 TPBSWG=0.0016588
 + TRNQSMOD=0 U0=0.0151 UA=1.78E-9 UA1=1.41E-9 UB=4.88E-19 UB1=-4.31E-18
 + UC=-2.7435E-11 UC1=1.147552E-10 UTE=-1.2 VFB=-1 VOFF=-0.1284 VOFFCV=0
-+ VOFFL=2.19E-8 VSAT=8.55E4 VTH0={pmos_6p0_vth0} VTL=2E5 W0=3.1E-7 WBETA0=0.22
++ VOFFL=2.19E-8 VSAT=8.55E4 VTH0={pfet_06v0_vth0} VTL=2E5 W0=3.1E-7 WBETA0=0.22
 + WINT=4.9E-8 WKETA=2.772E-3 WL=0 WLN=1 WMAX=100.01e-6 WMIN=0.3e-6 WR=1
 + WRDSW=213.9 WUA1=-1.2E-10 WUTE=-0.07 WW=-1.37E-14 WWL=3.04E-22 WWN=1
-+ XJ={pmos_6p0_xj} XJBVD=1 XJBVS=1 XL={pmos_6p0_xl} XN=3 XPART=1 XTID=3 XTIS=3
-+ XW={pmos_6p0_xw}
++ XJ={pfet_06v0_xj} XJBVD=1 XJBVS=1 XL={pfet_06v0_xl} XN=3 XPART=1 XTID=3 XTIS=3
++ XW={pfet_06v0_xw}
 + LEVEL=14
 ***** Flag Parameter ***
 ***** Geometry Range Parameter ***
@@ -46936,7 +46936,7 @@ Rb 1 2
 + R='r_temp*r_n*(r_rsh0+r_vc1*abs(v(1,2))/r_n+r_vc2*abs(v(1,2))*abs(v(1,2))/r_n/r_n)'
 *-------------------
 .ENDS pplus_u_m2
-.ENDL pmos_6p0_stat
+.ENDL pfet_06v0_stat
 
 *
 .LIB efuse
@@ -46975,7 +46975,7 @@ Rfuse in out R='200*(1-pblow) + 900*pblow'
 
 .LIB fets_mm
 
-.SUBCKT nmos_3p3 d g s b
+.SUBCKT nfet_03v3 d g s b
 + PARAMS: W=1e-5 L=2.8e-7 AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0 PAR=1 DTEMP=0 SA=0 SB=0 NF=1
 + SD=0 M=1
 .PARAM
@@ -46993,14 +46993,14 @@ Rfuse in out R='200*(1-pblow) + 900*pblow'
 + VAR_VTH='0.7071*par_vth* 1e-06 / p_sqrtarea' MIS_VTH={agauss(0,var_vth,1)}
 
 
-M0 d g s b nmos_3p3
+M0 d g s b nfet_03v3
 + AD={ad} AS={as} L={l} NRD={nrd} NRS={nrs} PD={pd} PS={ps} W={w}
 
 
-.ENDS nmos_3p3
+.ENDS nfet_03v3
 
 *------------------------------------------------------------------------
-.SUBCKT pmos_3p3 d g s b
+.SUBCKT pfet_03v3 d g s b
 + PARAMS: W=1e-5 L=2.8e-7 AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0 PAR=1 DTEMP=0 SA=0 SB=0 NF=1
 + SD=0 M=1
 .PARAM
@@ -47018,14 +47018,14 @@ M0 d g s b nmos_3p3
 + VAR_VTH='0.7071*par_vth* 1e-06 / p_sqrtarea' MIS_VTH={agauss(0,var_vth,1)}
 
 
-M0 d g s b pmos_3p3
+M0 d g s b pfet_03v3
 + AD={ad} AS={as} L={l} NRD={nrd} NRS={nrs} PD={pd} PS={ps} W={w}
 
 
-.ENDS pmos_3p3
+.ENDS pfet_03v3
 
 *------------------------------------------------------------------------
-.SUBCKT nmos_6p0 d g s b
+.SUBCKT nfet_06v0 d g s b
 + PARAMS: W=1e-5 L=7e-7 AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0 PAR=1 DTEMP=0 SA=0 SB=0 NF=1
 + SD=0 M=1
 .PARAM
@@ -47043,14 +47043,14 @@ M0 d g s b pmos_3p3
 + VAR_VTH='0.7071*par_vth* 1e-06 / p_sqrtarea' MIS_VTH={agauss(0,var_vth,1)}
 
 
-M0 d g s b nmos_6p0
+M0 d g s b nfet_06v0
 + AD={ad} AS={as} L={l} NRD={nrd} NRS={nrs} PD={pd} PS={ps} W={w}
 
 
-.ENDS nmos_6p0
+.ENDS nfet_06v0
 
 *------------------------------------------------------------------------
-.SUBCKT pmos_6p0 d g s b
+.SUBCKT pfet_06v0 d g s b
 + PARAMS: W=1e-5 L=5e-7 AS=0 AD=0 PS=0 PD=0 NRD=0 NRS=0 PAR=1 DTEMP=0 SA=0 SB=0 NF=1
 + SD=0 M=1
 .PARAM
@@ -47068,11 +47068,11 @@ M0 d g s b nmos_6p0
 + VAR_VTH='0.7071*par_vth* 1e-06 / p_sqrtarea' MIS_VTH={agauss(0,var_vth,1)}
 
 
-M0 d g s b pmos_6p0
+M0 d g s b pfet_06v0
 + AD={ad} AS={as} L={l} NRD={nrd} NRS={nrs} PD={pd} PS={ps} W={w}
 
 
-.ENDS pmos_6p0
+.ENDS pfet_06v0
 
 *------------------------------------------------------------------------
 .ENDL fets_mm
@@ -47275,56 +47275,56 @@ M0 d g s b pmos_6p0
 .ENDL bjt_statistical
 .LIB bjt_mc
 
-.SUBCKT vpnp_0p42x10 c b e PARAMS: PAR=1 DTEMP=0
+.SUBCKT pnp_10p00x00p42 c b e PARAMS: PAR=1 DTEMP=0
 
 .PARAM
-+ MIS_IS_VPNP_0P42X10={agauss(0,0.0015,1)} MIS_BF_VPNP_0P42X10={agauss(0,0.01088,1)}
-+ ISA_MIS_VPNP_0P42X10='mis_is_vpnp_0p42x10*sw_stat_mismatch / sqrt(par)' BF_MIS_VPNP_0P42X10='mis_bf_vpnp_0p42x10*sw_stat_mismatch / sqrt(par)'
-Q0 c b e vpnp_0p42x10
++ MIS_IS_pnp_10p00x00p42={agauss(0,0.0015,1)} MIS_BF_pnp_10p00x00p42={agauss(0,0.01088,1)}
++ ISA_MIS_pnp_10p00x00p42='mis_is_pnp_10p00x00p42*sw_stat_mismatch / sqrt(par)' BF_MIS_pnp_10p00x00p42='mis_bf_pnp_10p00x00p42*sw_stat_mismatch / sqrt(par)'
+Q0 c b e pnp_10p00x00p42
 
 
 
 
 
-.MODEL vpnp_0p42x10 PNP
-+ AF=1 BF='1.69*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + bf_mis_vpnp_0p42x10)'
+.MODEL pnp_10p00x00p42 PNP
++ AF=1 BF='1.69*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + bf_mis_pnp_10p00x00p42)'
 + BR=0.0036 CJC='2.04e-014*cjca*(1 + mc_xcjc_vpnp*sw_stat_global)'
 + CJE='6.88e-015*cjea*(1 + mc_xcje_vpnp*sw_stat_global)' CJS=0 EG=1.17 FC=0.5
 + IKF=0.00063375 IKR=0.1 IRB=0.1
-+ IS='9e-019*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + isa_mis_vpnp_0p42x10)'
++ IS='9e-019*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + isa_mis_pnp_10p00x00p42)'
 + ISC=1e-018 ISE=2.7e-016 ITF=0.1 KF=0 MJC=0.22711 MJE=0.14469 MJS=0.5 NC=2
 + NE=1.64 NF=1 NKF=0.4 NR=1 PTF=0 RB='41*rba*(1 + mc_xrb_vpnp*sw_stat_global)'
 + RBM='10*rbma' RC='10*rca*(1 + mc_xrc_vpnp*sw_stat_global)'
 + RE='1*rea*(1 + mc_xre_vpnp*sw_stat_global)' TF=1e-010 TR=0 VAF=80 VAR=23
 + VJC=0.43905 VJE=0.43905 VJS=0.75 VTF=10 XCJC=1 XTB=0.0001 XTF=1 XTI=3
 + LEVEL=1
-.ENDS vpnp_0p42x10
+.ENDS pnp_10p00x00p42
 
 
 
 
 
-.SUBCKT vpnp_0p42x5 c b e PARAMS: PAR=1 DTEMP=0
+.SUBCKT pnp_05p00x00p42 c b e PARAMS: PAR=1 DTEMP=0
 
 .PARAM
-+ MIS_IS_VPNP_0P42X5={agauss(0,0.0017,1)} MIS_BF_VPNP_0P42X5={agauss(0,0.0119,1)}
-Q0 c b e vpnp_0p42x5
++ MIS_IS_pnp_05p00x00p42={agauss(0,0.0017,1)} MIS_BF_pnp_05p00x00p42={agauss(0,0.0119,1)}
+Q0 c b e pnp_05p00x00p42
 
 
-.MODEL vpnp_0p42x5 PNP
+.MODEL pnp_05p00x00p42 PNP
 + AF=1
-+ BF='1.681*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_vpnp_0p42x5*sw_stat_mismatch / sqrt(par))'
++ BF='1.681*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_pnp_05p00x00p42*sw_stat_mismatch / sqrt(par))'
 + BR=1.9872E-3 CJC='1.17E-14*cjca*(1 + mc_xcjc_vpnp*sw_stat_global)'
 + CJE='3.5E-15*cjea*(1 + mc_xcje_vpnp*sw_stat_global)' CJS=0 EG=1.17 FC=0.5
 + IKF=2.4777E-4 IKR=0.1 IRB=0.1
-+ IS='4.388E-19*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_vpnp_0p42x5*sw_stat_mismatch / sqrt(par))'
++ IS='4.388E-19*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_pnp_05p00x00p42*sw_stat_mismatch / sqrt(par))'
 + ISC=1E-16 ISE=1.2124E-16 ITF=0.1 KF=0 MJC=0.22711 MJE=0.15395 MJS=0.5 NC=2
 + NE=1.64 NF=1 NKF=0.4 NR=1 PTF=0 RB='41*rba*(1 + mc_xrb_vpnp*sw_stat_global)'
 + RBM='10*rbma' RC='10*rca*(1 + mc_xrc_vpnp*sw_stat_global)'
 + RE='1*rea*(1 + mc_xre_vpnp*sw_stat_global)' TF=1E-10 TR=0 VAF=180 VAR=23
 + VJC=0.43905 VJE=0.43905 VJS=0.75 VTF=10 XCJC=1 XTB=1E-4 XTF=1 XTI=3
 + LEVEL=1
-.ENDS vpnp_0p42x5
+.ENDS pnp_05p00x00p42
 
 
 
@@ -47333,28 +47333,28 @@ Q0 c b e vpnp_0p42x5
 
 
 
-.SUBCKT vpnp_10x10 c b e PARAMS: PAR=1 DTEMP=0
+.SUBCKT pnp_10p00x10p00 c b e PARAMS: PAR=1 DTEMP=0
 
 
 .PARAM
-+ MIS_IS_VPNP_10X10={agauss(0,0.00077,1)} MIS_BF_VPNP_10X10={agauss(0,0.0013,1)}
-Q0 c b e vpnp_10x10
++ MIS_IS_pnp_10p00x10p00={agauss(0,0.00077,1)} MIS_BF_pnp_10p00x10p00={agauss(0,0.0013,1)}
+Q0 c b e pnp_10p00x10p00
 
 
-.MODEL vpnp_10x10 PNP
+.MODEL pnp_10p00x10p00 PNP
 + AF=1
-+ BF='1.7*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_vpnp_10x10*sw_stat_mismatch / sqrt(par))'
++ BF='1.7*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 + mis_bf_pnp_10p00x10p00*sw_stat_mismatch / sqrt(par))'
 + BR=0.017038 CJC='4.69E-14*cjca*(1 + mc_xcjc_vpnp*sw_stat_global)'
 + CJE='9.71E-14*cjea*(1 + mc_xcje_vpnp*sw_stat_global)' CJS=0 EG=1.17 FC=0.5
 + IKF=2.610625E-3 IKR=0.1 IRB=0.1
-+ IS='1.249175E-17*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_vpnp_10x10*sw_stat_mismatch / sqrt(par))'
++ IS='1.249175E-17*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_pnp_10p00x10p00*sw_stat_mismatch / sqrt(par))'
 + ISC=1E-18 ISE=2.7E-16 ITF=0.1 KF=0 MJC=0.24528 MJE=0.24192 MJS=0.5 NC=2 NE=1.64
 + NF=1 NKF=0.4 NR=1 PTF=0 RB='27.88*rba*(1 + mc_xrb_vpnp*sw_stat_global)'
 + RBM='10*rbma' RC='10*rca*(1 + mc_xrc_vpnp*sw_stat_global)'
 + RE='1*rea*(1 + mc_xre_vpnp*sw_stat_global)' TF=1E-10 TR=0 VAF=206.4 VAR=23
 + VJC=0.43905 VJE=0.43905 VJS=0.75 VTF=10 XCJC=1 XTB=1E-4 XTF=1 XTI=3
 + LEVEL=1
-.ENDS vpnp_10x10
+.ENDS pnp_10p00x10p00
 
 
 
@@ -47363,28 +47363,28 @@ Q0 c b e vpnp_10x10
 
 
 
-.SUBCKT vpnp_5x5 c b e PARAMS: PAR=1 DTEMP=0
+.SUBCKT pnp_05p00x05p00 c b e PARAMS: PAR=1 DTEMP=0
 
 .PARAM
-+ MIS_IS_VPNP_5X5={agauss(0,0.00052,1)} MIS_BF_VPNP_5X5={agauss(0,0.0031,1)}
-Q0 c b e vpnp_5x5
++ MIS_IS_pnp_05p00x05p00={agauss(0,0.00052,1)} MIS_BF_pnp_05p00x05p00={agauss(0,0.0031,1)}
+Q0 c b e pnp_05p00x05p00
 
 
 
-.MODEL vpnp_5x5 PNP
+.MODEL pnp_05p00x05p00 PNP
 + AF=1
-+ BF='1.65*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 +mis_bf_vpnp_5x5*sw_stat_mismatch / sqrt(par))'
++ BF='1.65*bfa*(1 + mc_xbf_vpnp*sw_stat_global)*(1 +mis_bf_pnp_05p00x05p00*sw_stat_mismatch / sqrt(par))'
 + BR=8.372E-3 CJC='2.15E-14*cjca*(1 + mc_xcjc_vpnp*sw_stat_global)'
 + CJE='2.57E-14*cjea*(1 + mc_xcje_vpnp*sw_stat_global)' CJS=0 EG=1.17 FC=0.5
 + IKF=1.025275E-3 IKR=0.1 IRB=0.1
-+ IS='3.403E-18*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_vpnp_5x5*sw_stat_mismatch / sqrt(par))'
++ IS='3.403E-18*isa*(1 + mc_xis_vpnp*sw_stat_global)*(1 + mis_is_pnp_05p00x05p00*sw_stat_mismatch / sqrt(par))'
 + ISC=1E-18 ISE=2.7E-16 ITF=0.1 KF=0 MJC=0.22711 MJE=0.23266 MJS=0.5 NC=2 NE=1.64
 + NF=1 NKF=0.4 NR=1 PTF=0 RB='41*rba*(1 + mc_xrb_vpnp*sw_stat_global)'
 + RBM='10*rbma' RC='10*rca*(1 + mc_xrc_vpnp*sw_stat_global)'
 + RE='1*rea*(1 + mc_xre_vpnp*sw_stat_global)' TF=1E-10 TR=0 VAF=208.8 VAR=27.37
 + VJC=0.43905 VJE=0.43905 VJS=0.75 VTF=10 XCJC=1 XTB=1E-4 XTF=1 XTI=3
 + LEVEL=1
-.ENDS vpnp_5x5
+.ENDS pnp_05p00x05p00
 
 
 
@@ -47393,11 +47393,11 @@ Q0 c b e vpnp_5x5
 
 
 
-.SUBCKT vnpn_10x10 c b e s PARAMS: PAR=1 DTEMP=0
+.SUBCKT npn_10p00x10p00 c b e s PARAMS: PAR=1 DTEMP=0
 
-Q0 c b e s vnpn_10x10
+Q0 c b e s npn_10p00x10p00
 
-.MODEL vnpn_10x10 NPN
+.MODEL npn_10p00x10p00 NPN
 + AF=1 BF='10.83*bf_cor_npn*(1 + mc_xbf_vnpn*sw_stat_global)' BR=0.258
 + CJC='7.053E-14*cjc_cor_npn*(1 + mc_xcjc_vnpn*sw_stat_global)'
 + CJE='1.031E-13*cje_cor_npn*(1 + mc_xcje_vnpn*sw_stat_global)' CJS=1.135E-13
@@ -47425,15 +47425,15 @@ Q0 c b e s vnpn_10x10
 **************************************************************
 *               TEMPERATURE PARAMETERS
 **************************************************************
-.ENDS vnpn_10x10
+.ENDS npn_10p00x10p00
 
 
 
-.SUBCKT vnpn_5x5 c b e s PARAMS: PAR=1 DTEMP=0
+.SUBCKT npn_05p00x05p00 c b e s PARAMS: PAR=1 DTEMP=0
 
-Q0 c b e s vnpn_5x5
+Q0 c b e s npn_05p00x05p00
 
-.MODEL vnpn_5x5 NPN
+.MODEL npn_05p00x05p00 NPN
 + AF=1 BF='10.05*bf_cor_npn*(1 + mc_xbf_vnpn*sw_stat_global)' BR=0.16573
 + CJC='2.972E-14*cjc_cor_npn*(1 + mc_xcjc_vnpn*sw_stat_global)'
 + CJE='2.733E-14*cje_cor_npn*(1 + mc_xcje_vnpn*sw_stat_global)' CJS=6.618E-14
@@ -47460,16 +47460,16 @@ Q0 c b e s vnpn_5x5
 **************************************************************
 *               TEMPERATURE PARAMETERS
 **************************************************************
-.ENDS vnpn_5x5
+.ENDS npn_05p00x05p00
 
 
 
-.SUBCKT vnpn_0p54x16 c b e s PARAMS: PAR=1 DTEMP=0
+.SUBCKT npn_00p54x16p00 c b e s PARAMS: PAR=1 DTEMP=0
 
-Q0 c b e s vnpn_0p54x16
+Q0 c b e s npn_00p54x16p00
 
 
-.MODEL vnpn_0p54x16 NPN
+.MODEL npn_00p54x16p00 NPN
 + AF=1 BF='8.4987*bf_cor_npn*(1 + mc_xbf_vnpn*sw_stat_global)' BR=0.079582
 + CJC='3.540E-14*cjc_cor_npn*(1 + mc_xcjc_vnpn*sw_stat_global)'
 + CJE='1.354E-14*cje_cor_npn*(1 + mc_xcje_vnpn*sw_stat_global)' CJS=8.211E-14
@@ -47496,15 +47496,15 @@ Q0 c b e s vnpn_0p54x16
 **************************************************************
 *               TEMPERATURE PARAMETERS
 **************************************************************
-.ENDS vnpn_0p54x16
+.ENDS npn_00p54x16p00
 
 
 
-.SUBCKT vnpn_0p54x8 c b e s PARAMS: PAR=1 DTEMP=0
+.SUBCKT npn_00p54x08p00 c b e s PARAMS: PAR=1 DTEMP=0
 
-Q0 c b e s vnpn_0p54x8
+Q0 c b e s npn_00p54x08p00
 
-.MODEL vnpn_0p54x8 NPN
+.MODEL npn_00p54x08p00 NPN
 + AF=1 BF='8.4*bf_cor_npn*(1 + mc_xbf_vnpn*sw_stat_global)' BR=0.069974
 + CJC='2.064E-14*cjc_cor_npn*(1 + mc_xcjc_vnpn*sw_stat_global)'
 + CJE='6.857E-15*cje_cor_npn*(1 + mc_xcje_vnpn*sw_stat_global)' CJS=5.703E-14
@@ -47532,16 +47532,16 @@ Q0 c b e s vnpn_0p54x8
 **************************************************************
 *               TEMPERATURE PARAMETERS
 **************************************************************
-.ENDS vnpn_0p54x8
+.ENDS npn_00p54x08p00
 
 
 
-.SUBCKT vnpn_0p54x4 c b e s PARAMS: PAR=1 DTEMP=0
+.SUBCKT npn_00p54x04p00 c b e s PARAMS: PAR=1 DTEMP=0
 
-Q0 c b e s vnpn_0p54x4
+Q0 c b e s npn_00p54x04p00
 
 
-.MODEL vnpn_0p54x4 NPN
+.MODEL npn_00p54x04p00 NPN
 + AF=1 BF='8.39*bf_cor_npn*(1 + mc_xbf_vnpn*sw_stat_global)' BR=0.057751
 + CJC='1.326E-14*cjc_cor_npn*(1 + mc_xcjc_vnpn*sw_stat_global)'
 + CJE='3.513E-15*cje_cor_npn*(1 + mc_xcje_vnpn*sw_stat_global)' CJS=4.449E-14
@@ -47569,14 +47569,14 @@ Q0 c b e s vnpn_0p54x4
 **************************************************************
 *               TEMPERATURE PARAMETERS
 **************************************************************
-.ENDS vnpn_0p54x4
+.ENDS npn_00p54x04p00
 
 
-.SUBCKT vnpn_0p54x2 c b e s PARAMS: PAR=1 DTEMP=0
-Q0 c b e s vnpn_0p54x2
+.SUBCKT npn_00p54x02p00 c b e s PARAMS: PAR=1 DTEMP=0
+Q0 c b e s npn_00p54x02p00
 
 
-.MODEL vnpn_0p54x2 NPN
+.MODEL npn_00p54x02p00 NPN
 + AF=1 BF='8.25*bf_cor_npn*(1 + mc_xbf_vnpn*sw_stat_global)' BR=0.043698
 + CJC='9.569E-15*cjc_cor_npn*(1 + mc_xcjc_vnpn*sw_stat_global)'
 + CJE='1.841E-15*cje_cor_npn*(1 + mc_xcje_vnpn*sw_stat_global)' CJS=3.822E-14
@@ -47603,7 +47603,7 @@ Q0 c b e s vnpn_0p54x2
 **************************************************************
 *               TEMPERATURE PARAMETERS
 **************************************************************
-.ENDS vnpn_0p54x2
+.ENDS npn_00p54x02p00
 
 
 
@@ -47617,7 +47617,7 @@ Q0 c b e s vnpn_0p54x2
 + MC_C_COX_1P0FF2={agauss(0, 0.025, 3)} MC_C_COX_1P5FF2={agauss(0, 0.03875, 3)} MC_C_COX_2P0FF2={agauss(0, 0.025, 3)}
 + MC_C_COX_1P0FF='mc_c_cox_1p0fF2*sw_stat_global*cap_mc_skew' MC_C_COX_1P5FF='mc_c_cox_1p5fF2*sw_stat_global*cap_mc_skew'
 + MC_C_COX_2P0FF='mc_c_cox_2p0fF2*sw_stat_global*cap_mc_skew'
-.LIB sm141064.xyce mim_cap
+.LIB sm141064_mim.xyce cap_mim_new
 
 
 

--- a/models/xyce/sm141064_mim.xyce
+++ b/models/xyce/sm141064_mim.xyce
@@ -1,0 +1,226 @@
+* ----------------------------------------------------------------------------------------------------
+.LIB cap_mim_new
+* ----------------------------------------------------------------------------------------------------
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-A [3LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f5_m2m3_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='1.47e-3*mim_corner_1p5fF' C_CAPSW='3.79e-10*mim_corner_1p5fF' C_TNOM=25 C_TC1=4.0604E-05
++ C_TC2=-6.90E-08 C_VCR1=-4.5152E-05 C_VCR2=9.748E-06 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ENDS cap_mim_1f5_m2m3_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f0_m2m3_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='0.987e-3*mim_corner_1p0fF' C_CAPSW='3.3e-10*mim_corner_1p0fF' C_TNOM=25 C_TC1=1.302e-5
++ C_TC2=-4.93e-9 C_VCR1=6.079e-6 C_VCR2=1.268e-6 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ENDS cap_mim_1f0_m2m3_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_2f0_m2m3_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM GLEAK='9.51e-10/5*10000'
+.PARAM C_COX='1.99e-3*mim_corner_2p0fF'
+.PARAM C_CAPSW='2.383e-10*mim_corner_2p0fF'
+.PARAM
++ C_VCR1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.PARAM
++ C_VCR2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+.PARAM C_TNOM=25
+.PARAM C_TC1=1.46e-5
+.PARAM C_TC2=-5.55e-8
+.PARAM C_AREA='c_length*c_width'
+.PARAM C_PERI='2*(c_length+c_width)'
+.PARAM
++ C_C0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temp +dtemp -c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*
+C_cap 1 2 C='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+R_leak 1 2 R='1/(gleak*c_AREA)' TC1={c_tc1} TC2={c_tc2}
+.ENDS cap_mim_2f0_m2m3_noshield
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-B [4LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f5_m3m4_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='1.47e-3*mim_corner_1p5fF' C_CAPSW='3.79e-10*mim_corner_1p5fF' C_TNOM=25 C_TC1=4.0604E-05
++ C_TC2=-6.90E-08 C_VCR1=-4.5152E-05 C_VCR2=9.748E-06 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ENDS cap_mim_1f5_m3m4_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f0_m3m4_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='0.987e-3*mim_corner_1p0fF' C_CAPSW='3.3e-10*mim_corner_1p0fF' C_TNOM=25 C_TC1=1.302e-5
++ C_TC2=-4.93e-9 C_VCR1=6.079e-6 C_VCR2=1.268e-6 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ENDS cap_mim_1f0_m3m4_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_2f0_m3m4_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM GLEAK='9.51e-10/5*10000'
+.PARAM C_COX='1.99e-3*mim_corner_2p0fF'
+.PARAM C_CAPSW='2.383e-10*mim_corner_2p0fF'
+.PARAM
++ C_VCR1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.PARAM
++ C_VCR2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+.PARAM C_TNOM=25
+.PARAM C_TC1=1.46e-5
+.PARAM C_TC2=-5.55e-8
+.PARAM C_AREA='c_length*c_width'
+.PARAM C_PERI='2*(c_length+c_width)'
+.PARAM
++ C_C0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temp +dtemp -c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*
+C_cap 1 2 C='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+R_leak 1 2 R='1/(gleak*c_AREA)' TC1={c_tc1} TC2={c_tc2}
+.ENDS cap_mim_2f0_m3m4_noshield
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-B [5LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f5_m4m5_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='1.47e-3*mim_corner_1p5fF' C_CAPSW='3.79e-10*mim_corner_1p5fF' C_TNOM=25 C_TC1=4.0604E-05
++ C_TC2=-6.90E-08 C_VCR1=-4.5152E-05 C_VCR2=9.748E-06 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ENDS cap_mim_1f5_m4m5_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f0_m4m5_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='0.987e-3*mim_corner_1p0fF' C_CAPSW='3.3e-10*mim_corner_1p0fF' C_TNOM=25 C_TC1=1.302e-5
++ C_TC2=-4.93e-9 C_VCR1=6.079e-6 C_VCR2=1.268e-6 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ENDS cap_mim_1f0_m4m5_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_2f0_m4m5_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM GLEAK='9.51e-10/5*10000'
+.PARAM C_COX='1.99e-3*mim_corner_2p0fF'
+.PARAM C_CAPSW='2.383e-10*mim_corner_2p0fF'
+.PARAM
++ C_VCR1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.PARAM
++ C_VCR2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+.PARAM C_TNOM=25
+.PARAM C_TC1=1.46e-5
+.PARAM C_TC2=-5.55e-8
+.PARAM C_AREA='c_length*c_width'
+.PARAM C_PERI='2*(c_length+c_width)'
+.PARAM
++ C_C0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temp +dtemp -c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*
+C_cap 1 2 C='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+R_leak 1 2 R='1/(gleak*c_AREA)' TC1={c_tc1} TC2={c_tc2}
+.ENDS cap_mim_2f0_m4m5_noshield
+
+* ----------------------------------------------------------------------------------------------------
+* OPTION-B [6LM]
+* ----------------------------------------------------------------------------------------------------
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1.5fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f5_m5m6_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='1.47e-3*mim_corner_1p5fF' C_CAPSW='3.79e-10*mim_corner_1p5fF' C_TNOM=25 C_TC1=4.0604E-05
++ C_TC2=-6.90E-08 C_VCR1=-4.5152E-05 C_VCR2=9.748E-06 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p5fF)'
+**
+.ENDS cap_mim_1f5_m5m6_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (1fF/um2) subcircuit model for GF's 0.18 Analog CMOS process
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_1f0_m5m6_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM
++ C_COX='0.987e-3*mim_corner_1p0fF' C_CAPSW='3.3e-10*mim_corner_1p0fF' C_TNOM=25 C_TC1=1.302e-5
++ C_TC2=-4.93e-9 C_VCR1=6.079e-6 C_VCR2=1.268e-6 C_AREA='c_length*c_width' C_PERI='2*(c_length+c_width)'
++ C_C0='(c_cox*c_area+c_capsw*c_peri)*(1+c_tc1*(temp+dtemp-c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*/
+*/ model for capacitance
+C_cap 1 2 C='c_c0*(1+ c_vcr1*v(1, 2)+c_vcr2*v(1,2)*v(1,2) )*(1+mc_c_cox_1p0fF)'
+**
+.ENDS cap_mim_1f0_m5m6_noshield
+
+*/ -------------------------------------------------------------------------------------
+*/ MIM Capacitor (2fF/um2) subcircuit model for GLOBALFOUNDRIES 0.18 Analog CMOS process M2-M3
+*/--------------------------------------------------------------------------------------
+.SUBCKT cap_mim_2f0_m5m6_noshield 1 2 PARAMS: C_LENGTH={l} C_WIDTH={w} DTEMP=0 PAR=1
+.PARAM GLEAK='9.51e-10/5*10000'
+.PARAM C_COX='1.99e-3*mim_corner_2p0fF'
+.PARAM C_CAPSW='2.383e-10*mim_corner_2p0fF'
+.PARAM
++ C_VCR1='0+(c_width>5u||c_length>5u)*8.742e-6+(c_width<=5u||c_length<=5u)*(-81e-6)'
+.PARAM
++ C_VCR2='0+(c_width>5u||c_length>5u)*9.188e-6+(c_width<=5u||c_length<=5u)*(16.7e-6)'
+.PARAM C_TNOM=25
+.PARAM C_TC1=1.46e-5
+.PARAM C_TC2=-5.55e-8
+.PARAM C_AREA='c_length*c_width'
+.PARAM C_PERI='2*(c_length+c_width)'
+.PARAM
++ C_C0='(c_cox*c_AREA+c_capsw*c_PERI)*(1+c_tc1*(temp +dtemp -c_tnom)+c_tc2*(temp+dtemp-c_tnom)*(temp+dtemp-c_tnom))'
+*
+C_cap 1 2 C='c_c0*(1+c_vcr1*v(1,2)+c_vcr2*v(1,2)*v(1,2))*(1+mc_c_cox_2p0fF)'
+R_leak 1 2 R='1/(gleak*c_AREA)' TC1={c_tc1} TC2={c_tc2}
+.ENDS cap_mim_2f0_m5m6_noshield
+
+.ENDL cap_mim_new
+* ----------------------------------------------------------------------------------------------------

--- a/models/xyce/smbb000149.xyce
+++ b/models/xyce/smbb000149.xyce
@@ -30,8 +30,8 @@
 *
 *      ModelName          Description
 *      ---------          -----------
-*      nmos_10p0_asym     BSIM4 based HV subcircuit model for 10V LDNMOS (*)
-*      pmos_10p0_asym     BSIM4 based HV subcircuit model for 10V LDPMOS (*)
+*      nfet_10v0_asym     BSIM4 based HV subcircuit model for 10V LDNMOS (*)
+*      pfet_10v0_asym     BSIM4 based HV subcircuit model for 10V LDPMOS (*)
 ************************************************************************************************
 *
 ***************************************************************************************************
@@ -39,14 +39,14 @@
 ***************************************************************************************************
 .LIB typical
 .PARAM
-+ NMOS_10P0_ASYM_DTOX=0 NMOS_10P0_ASYM_DXL=0 NMOS_10P0_ASYM_DXW=0 NMOS_10P0_ASYM_DVTH0=0
-+ NMOS_10P0_ASYM_DRDSW=1 NMOS_10P0_ASYM_DRDRIFT=1 NMOS_10P0_ASYM_DVSAT=1 NMOS_10P0_ASYM_DU0=1
-+ NMOS_10P0_ASYM_DCGS=1 NMOS_10P0_ASYM_DCGD=1 NMOS_10P0_ASYM_DCJS=1 NMOS_10P0_ASYM_DCJD=1
-+ PMOS_10P0_ASYM_DTOX=0 PMOS_10P0_ASYM_DXL=0 PMOS_10P0_ASYM_DXW=0 PMOS_10P0_ASYM_DVTH0=0
-+ PMOS_10P0_ASYM_DRDSW=1 PMOS_10P0_ASYM_DRDRIFT=1 PMOS_10P0_ASYM_DVSAT=1 PMOS_10P0_ASYM_DU0=1
-+ PMOS_10P0_ASYM_DCGS=1 PMOS_10P0_ASYM_DCGD=1 PMOS_10P0_ASYM_DCJS=1 PMOS_10P0_ASYM_DCJD=1
++ nfet_10v0_asym_DTOX=0 nfet_10v0_asym_DXL=0 nfet_10v0_asym_DXW=0 nfet_10v0_asym_DVTH0=0
++ nfet_10v0_asym_DRDSW=1 nfet_10v0_asym_DRDRIFT=1 nfet_10v0_asym_DVSAT=1 nfet_10v0_asym_DU0=1
++ nfet_10v0_asym_DCGS=1 nfet_10v0_asym_DCGD=1 nfet_10v0_asym_DCJS=1 nfet_10v0_asym_DCJD=1
++ pfet_10v0_asym_DTOX=0 pfet_10v0_asym_DXL=0 pfet_10v0_asym_DXW=0 pfet_10v0_asym_DVTH0=0
++ pfet_10v0_asym_DRDSW=1 pfet_10v0_asym_DRDRIFT=1 pfet_10v0_asym_DVSAT=1 pfet_10v0_asym_DU0=1
++ pfet_10v0_asym_DCGS=1 pfet_10v0_asym_DCGD=1 pfet_10v0_asym_DCJS=1 pfet_10v0_asym_DCJD=1
 *************10V************
-.LIB smbb000149.xyce nmos_10p0_asym_t
+.LIB smbb000149.xyce nfet_10v0_asym_t
 
 
 
@@ -68,7 +68,7 @@
 
 
 
-.LIB smbb000149.xyce pmos_10p0_asym_t
+.LIB smbb000149.xyce pfet_10v0_asym_t
 .LIB smbb000149.xyce noise_corner
 .ENDL
 
@@ -76,14 +76,14 @@
 .LIB ss
 
 .PARAM
-+ NMOS_10P0_ASYM_DTOX=8E-10 NMOS_10P0_ASYM_DXL=6e-008 NMOS_10P0_ASYM_DXW=-3.46E-8 NMOS_10P0_ASYM_DVTH0=0.112
-+ NMOS_10P0_ASYM_DRDSW=1.2 NMOS_10P0_ASYM_DRDRIFT=1.271 NMOS_10P0_ASYM_DVSAT=0.926
-+ NMOS_10P0_ASYM_DU0=0.95 NMOS_10P0_ASYM_DCGS=1.1 NMOS_10P0_ASYM_DCGD=1.2 NMOS_10P0_ASYM_DCJS=1.1
-+ NMOS_10P0_ASYM_DCJD=1.2 PMOS_10P0_ASYM_DTOX=8E-10 PMOS_10P0_ASYM_DXL=9.914e-008
-+ PMOS_10P0_ASYM_DXW=-1E-7 PMOS_10P0_ASYM_DVTH0=-0.0936 PMOS_10P0_ASYM_DRDSW=1.11
-+ PMOS_10P0_ASYM_DRDRIFT=1.144 PMOS_10P0_ASYM_DVSAT=0.91 PMOS_10P0_ASYM_DU0=0.964
-+ PMOS_10P0_ASYM_DCGS=1.1 PMOS_10P0_ASYM_DCGD=1.2 PMOS_10P0_ASYM_DCJS=1.1 PMOS_10P0_ASYM_DCJD=1.2
-.LIB smbb000149.xyce nmos_10p0_asym_t
++ nfet_10v0_asym_DTOX=8E-10 nfet_10v0_asym_DXL=6e-008 nfet_10v0_asym_DXW=-3.46E-8 nfet_10v0_asym_DVTH0=0.112
++ nfet_10v0_asym_DRDSW=1.2 nfet_10v0_asym_DRDRIFT=1.271 nfet_10v0_asym_DVSAT=0.926
++ nfet_10v0_asym_DU0=0.95 nfet_10v0_asym_DCGS=1.1 nfet_10v0_asym_DCGD=1.2 nfet_10v0_asym_DCJS=1.1
++ nfet_10v0_asym_DCJD=1.2 pfet_10v0_asym_DTOX=8E-10 pfet_10v0_asym_DXL=9.914e-008
++ pfet_10v0_asym_DXW=-1E-7 pfet_10v0_asym_DVTH0=-0.0936 pfet_10v0_asym_DRDSW=1.11
++ pfet_10v0_asym_DRDRIFT=1.144 pfet_10v0_asym_DVSAT=0.91 pfet_10v0_asym_DU0=0.964
++ pfet_10v0_asym_DCGS=1.1 pfet_10v0_asym_DCGD=1.2 pfet_10v0_asym_DCJS=1.1 pfet_10v0_asym_DCJD=1.2
+.LIB smbb000149.xyce nfet_10v0_asym_t
 
 
 
@@ -105,7 +105,7 @@
 
 
 
-.LIB smbb000149.xyce pmos_10p0_asym_t
+.LIB smbb000149.xyce pfet_10v0_asym_t
 .LIB smbb000149.xyce noise_corner
 .ENDL
 
@@ -113,14 +113,14 @@
 .LIB ff
 
 .PARAM
-+ NMOS_10P0_ASYM_DTOX=-8E-10 NMOS_10P0_ASYM_DXL=-6e-008 NMOS_10P0_ASYM_DXW=3.46E-8
-+ NMOS_10P0_ASYM_DVTH0=-0.10388 NMOS_10P0_ASYM_DRDSW=0.868 NMOS_10P0_ASYM_DRDRIFT=0.8245
-+ NMOS_10P0_ASYM_DVSAT=1.033 NMOS_10P0_ASYM_DU0=1.04 NMOS_10P0_ASYM_DCGS=0.9 NMOS_10P0_ASYM_DCGD=0.8
-+ NMOS_10P0_ASYM_DCJS=0.9 NMOS_10P0_ASYM_DCJD=0.8 PMOS_10P0_ASYM_DTOX=-8E-10 PMOS_10P0_ASYM_DXL=-6.804e-008
-+ PMOS_10P0_ASYM_DXW=8.46E-8 PMOS_10P0_ASYM_DVTH0=0.099 PMOS_10P0_ASYM_DRDSW=0.91
-+ PMOS_10P0_ASYM_DRDRIFT=0.89 PMOS_10P0_ASYM_DVSAT=1.06 PMOS_10P0_ASYM_DU0=1.03 PMOS_10P0_ASYM_DCGS=0.9
-+ PMOS_10P0_ASYM_DCGD=0.8 PMOS_10P0_ASYM_DCJS=0.9 PMOS_10P0_ASYM_DCJD=0.8
-.LIB smbb000149.xyce nmos_10p0_asym_t
++ nfet_10v0_asym_DTOX=-8E-10 nfet_10v0_asym_DXL=-6e-008 nfet_10v0_asym_DXW=3.46E-8
++ nfet_10v0_asym_DVTH0=-0.10388 nfet_10v0_asym_DRDSW=0.868 nfet_10v0_asym_DRDRIFT=0.8245
++ nfet_10v0_asym_DVSAT=1.033 nfet_10v0_asym_DU0=1.04 nfet_10v0_asym_DCGS=0.9 nfet_10v0_asym_DCGD=0.8
++ nfet_10v0_asym_DCJS=0.9 nfet_10v0_asym_DCJD=0.8 pfet_10v0_asym_DTOX=-8E-10 pfet_10v0_asym_DXL=-6.804e-008
++ pfet_10v0_asym_DXW=8.46E-8 pfet_10v0_asym_DVTH0=0.099 pfet_10v0_asym_DRDSW=0.91
++ pfet_10v0_asym_DRDRIFT=0.89 pfet_10v0_asym_DVSAT=1.06 pfet_10v0_asym_DU0=1.03 pfet_10v0_asym_DCGS=0.9
++ pfet_10v0_asym_DCGD=0.8 pfet_10v0_asym_DCJS=0.9 pfet_10v0_asym_DCJD=0.8
+.LIB smbb000149.xyce nfet_10v0_asym_t
 
 
 
@@ -143,7 +143,7 @@
 
 
 
-.LIB smbb000149.xyce pmos_10p0_asym_t
+.LIB smbb000149.xyce pfet_10v0_asym_t
 .LIB smbb000149.xyce noise_corner
 .ENDL
 
@@ -151,14 +151,14 @@
 
 
 .PARAM
-+ NMOS_10P0_ASYM_DTOX=0 NMOS_10P0_ASYM_DXL=5.024e-008 NMOS_10P0_ASYM_DXW=0 NMOS_10P0_ASYM_DVTH0=0.068
-+ NMOS_10P0_ASYM_DRDSW=1.2 NMOS_10P0_ASYM_DRDRIFT=1.156 NMOS_10P0_ASYM_DVSAT=0.928
-+ NMOS_10P0_ASYM_DU0=0.97 NMOS_10P0_ASYM_DCGS=1.07 NMOS_10P0_ASYM_DCGD=1.14 NMOS_10P0_ASYM_DCJS=1.07
-+ NMOS_10P0_ASYM_DCJD=1.14 PMOS_10P0_ASYM_DTOX=0 PMOS_10P0_ASYM_DXL=-7.004e-008 PMOS_10P0_ASYM_DXW=0
-+ PMOS_10P0_ASYM_DVTH0=0.057672 PMOS_10P0_ASYM_DRDSW=0.91 PMOS_10P0_ASYM_DRDRIFT=0.92
-+ PMOS_10P0_ASYM_DVSAT=1.012 PMOS_10P0_ASYM_DU0=1.03 PMOS_10P0_ASYM_DCGS=0.93 PMOS_10P0_ASYM_DCGD=0.86
-+ PMOS_10P0_ASYM_DCJS=0.93 PMOS_10P0_ASYM_DCJD=0.86
-.LIB smbb000149.xyce nmos_10p0_asym_t
++ nfet_10v0_asym_DTOX=0 nfet_10v0_asym_DXL=5.024e-008 nfet_10v0_asym_DXW=0 nfet_10v0_asym_DVTH0=0.068
++ nfet_10v0_asym_DRDSW=1.2 nfet_10v0_asym_DRDRIFT=1.156 nfet_10v0_asym_DVSAT=0.928
++ nfet_10v0_asym_DU0=0.97 nfet_10v0_asym_DCGS=1.07 nfet_10v0_asym_DCGD=1.14 nfet_10v0_asym_DCJS=1.07
++ nfet_10v0_asym_DCJD=1.14 pfet_10v0_asym_DTOX=0 pfet_10v0_asym_DXL=-7.004e-008 pfet_10v0_asym_DXW=0
++ pfet_10v0_asym_DVTH0=0.057672 pfet_10v0_asym_DRDSW=0.91 pfet_10v0_asym_DRDRIFT=0.92
++ pfet_10v0_asym_DVSAT=1.012 pfet_10v0_asym_DU0=1.03 pfet_10v0_asym_DCGS=0.93 pfet_10v0_asym_DCGD=0.86
++ pfet_10v0_asym_DCJS=0.93 pfet_10v0_asym_DCJD=0.86
+.LIB smbb000149.xyce nfet_10v0_asym_t
 
 
 
@@ -181,21 +181,21 @@
 
 
 
-.LIB smbb000149.xyce pmos_10p0_asym_t
+.LIB smbb000149.xyce pfet_10v0_asym_t
 .LIB smbb000149.xyce noise_corner
 .ENDL
 
 .LIB fs
 
 .PARAM
-+ NMOS_10P0_ASYM_DTOX=0 NMOS_10P0_ASYM_DXL=-5.02e-008 NMOS_10P0_ASYM_DXW=0 NMOS_10P0_ASYM_DVTH0=-0.058169
-+ NMOS_10P0_ASYM_DRDSW=0.868 NMOS_10P0_ASYM_DRDRIFT=0.89748 NMOS_10P0_ASYM_DVSAT=1.045
-+ NMOS_10P0_ASYM_DU0=1.034 NMOS_10P0_ASYM_DCGS=0.93 NMOS_10P0_ASYM_DCGD=0.86 NMOS_10P0_ASYM_DCJS=0.93
-+ NMOS_10P0_ASYM_DCJD=0.86 PMOS_10P0_ASYM_DTOX=0 PMOS_10P0_ASYM_DXL=9.414e-008 PMOS_10P0_ASYM_DXW=0
-+ PMOS_10P0_ASYM_DVTH0=-0.056 PMOS_10P0_ASYM_DRDSW=1.11 PMOS_10P0_ASYM_DRDRIFT=1.06
-+ PMOS_10P0_ASYM_DVSAT=0.989 PMOS_10P0_ASYM_DU0=0.97 PMOS_10P0_ASYM_DCGS=1.07 PMOS_10P0_ASYM_DCGD=1.14
-+ PMOS_10P0_ASYM_DCJS=1.07 PMOS_10P0_ASYM_DCJD=1.14
-.LIB smbb000149.xyce nmos_10p0_asym_t
++ nfet_10v0_asym_DTOX=0 nfet_10v0_asym_DXL=-5.02e-008 nfet_10v0_asym_DXW=0 nfet_10v0_asym_DVTH0=-0.058169
++ nfet_10v0_asym_DRDSW=0.868 nfet_10v0_asym_DRDRIFT=0.89748 nfet_10v0_asym_DVSAT=1.045
++ nfet_10v0_asym_DU0=1.034 nfet_10v0_asym_DCGS=0.93 nfet_10v0_asym_DCGD=0.86 nfet_10v0_asym_DCJS=0.93
++ nfet_10v0_asym_DCJD=0.86 pfet_10v0_asym_DTOX=0 pfet_10v0_asym_DXL=9.414e-008 pfet_10v0_asym_DXW=0
++ pfet_10v0_asym_DVTH0=-0.056 pfet_10v0_asym_DRDSW=1.11 pfet_10v0_asym_DRDRIFT=1.06
++ pfet_10v0_asym_DVSAT=0.989 pfet_10v0_asym_DU0=0.97 pfet_10v0_asym_DCGS=1.07 pfet_10v0_asym_DCGD=1.14
++ pfet_10v0_asym_DCJS=1.07 pfet_10v0_asym_DCJD=1.14
+.LIB smbb000149.xyce nfet_10v0_asym_t
 
 
 
@@ -216,7 +216,7 @@
 
 
 
-.LIB smbb000149.xyce pmos_10p0_asym_t
+.LIB smbb000149.xyce pfet_10v0_asym_t
 .LIB smbb000149.xyce noise_corner
 .ENDL
 
@@ -233,17 +233,17 @@
 + MC_CGOLN_10V={mc_cgolN_10V_2} MC_VSATP_10V={mc_vsatP2_10v} MC_U0P_10V={mc_u0P2_10v}
 + MC_RDP_10V={mc_rdP_10V_2} MC_CGOLP_10V={mc_cgolP_10V_2}
 .PARAM
-+ NMOS_10P0_ASYM_SIG_VTH='0.01675*(0.7*mc_sig_vth+0.7*mc_sig_vthN)*sw_stat_global*mc_skew'
-+ NMOS_10P0_ASYM_DTOX='7.2e-11*(0.77*mc_toxe+0.63*mc_toxeN)*sw_stat_global*mc_skew'
-+ NMOS_10P0_ASYM_DXL='5.3e-9*(0.71*mc_xl+0.69*mc_xlN)*sw_stat_global*mc_skew' NMOS_10P0_ASYM_DXW='3.25e-8*(0.77*mc_xw+0.63*mc_xwN)*sw_stat_global*mc_skew'
-+ NMOS_10P0_ASYM_DVTH0='nmos_10p0_asym_sig_vth' NMOS_10P0_ASYM_DRDSW='(1 + 0.093*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
-+ NMOS_10P0_ASYM_DRDRIFT='(1 + 0.037*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
-+ NMOS_10P0_ASYM_DVSAT='(1 + 0.028*(0.77*mc_vsat_10v+0.63*mc_vsatN_10v)*sw_stat_global*mc_skew)'
-+ NMOS_10P0_ASYM_DU0='(1 + 0.0157*(0.7*mc_u0_10v+0.7*mc_u0n_10v)*sw_stat_global*mc_skew)'
-+ NMOS_10P0_ASYM_DCGS='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
-+ NMOS_10P0_ASYM_DCGD='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
-+ NMOS_10P0_ASYM_DCJS='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
-+ NMOS_10P0_ASYM_DCJD='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_SIG_VTH='0.01675*(0.7*mc_sig_vth+0.7*mc_sig_vthN)*sw_stat_global*mc_skew'
++ nfet_10v0_asym_DTOX='7.2e-11*(0.77*mc_toxe+0.63*mc_toxeN)*sw_stat_global*mc_skew'
++ nfet_10v0_asym_DXL='5.3e-9*(0.71*mc_xl+0.69*mc_xlN)*sw_stat_global*mc_skew' nfet_10v0_asym_DXW='3.25e-8*(0.77*mc_xw+0.63*mc_xwN)*sw_stat_global*mc_skew'
++ nfet_10v0_asym_DVTH0='nfet_10v0_asym_sig_vth' nfet_10v0_asym_DRDSW='(1 + 0.093*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_DRDRIFT='(1 + 0.037*(0.77* mc_rd_10V + 0.63* mc_rdn_10V)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_DVSAT='(1 + 0.028*(0.77*mc_vsat_10v+0.63*mc_vsatN_10v)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_DU0='(1 + 0.0157*(0.7*mc_u0_10v+0.7*mc_u0n_10v)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_DCGS='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_DCGD='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_DCJS='(1+(12e-3* mc_cgol_10V+12e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
++ nfet_10v0_asym_DCJD='(1+(24e-3* mc_cgol_10V+24e-3* mc_cgolN_10V)*sw_stat_global*mc_skew)'
 
 
 
@@ -261,27 +261,22 @@
 
 
 .PARAM
-+ PMOS_10P0_ASYM_SIG_DVTH1='0.01692*(-0.7*mc_sig_vth+0.7*mc_sig_vthp)*sw_stat_global*mc_skew'
-+ PMOS_10P0_ASYM_DTOX='7.143e-11*(0.77*mc_toxe+0.63*mc_toxep)*sw_stat_global*mc_skew'
-+ PMOS_10P0_ASYM_DXL='1.7e-8*(0.71*mc_xl+0.69*mc_xlp)*sw_stat_global*mc_skew' PMOS_10P0_ASYM_DXW='7.4e-8*(0.77*mc_xw+0.63*mc_xwp)*sw_stat_global*mc_skew'
-+ PMOS_10P0_ASYM_DVTH0='pmos_10p0_asym_sig_dvth1' PMOS_10P0_ASYM_DRDSW='(1 + 0.085*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)'
-+ PMOS_10P0_ASYM_DRDRIFT='(1 + 0.032*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)'
-+ PMOS_10P0_ASYM_DVSAT='(1 + 0.032*(0.77*mc_vsat_10v+0.63*mc_vsatP_10V)*sw_stat_global*mc_skew)'
-+ PMOS_10P0_ASYM_DU0='(1 + 0.0097*(0.7*mc_u0_10v+0.7*mc_u0P_10V)*sw_stat_global*mc_skew)'
-+ PMOS_10P0_ASYM_DCGS='(1+ (12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
-+ PMOS_10P0_ASYM_DCGD='(1+ (24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
-+ PMOS_10P0_ASYM_DCJS='(1+(12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
-+ PMOS_10P0_ASYM_DCJD='(1+(24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_SIG_DVTH1='0.01692*(-0.7*mc_sig_vth+0.7*mc_sig_vthp)*sw_stat_global*mc_skew'
++ pfet_10v0_asym_DTOX='7.143e-11*(0.77*mc_toxe+0.63*mc_toxep)*sw_stat_global*mc_skew'
++ pfet_10v0_asym_DXL='1.7e-8*(0.71*mc_xl+0.69*mc_xlp)*sw_stat_global*mc_skew' pfet_10v0_asym_DXW='7.4e-8*(0.77*mc_xw+0.63*mc_xwp)*sw_stat_global*mc_skew'
++ pfet_10v0_asym_DVTH0='pfet_10v0_asym_sig_dvth1' pfet_10v0_asym_DRDSW='(1 + 0.085*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_DRDRIFT='(1 + 0.032*(0.77* mc_rd_10V + 0.63* mc_rdp_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_DVSAT='(1 + 0.032*(0.77*mc_vsat_10v+0.63*mc_vsatP_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_DU0='(1 + 0.0097*(0.7*mc_u0_10v+0.7*mc_u0P_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_DCGS='(1+ (12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_DCGD='(1+ (24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_DCJS='(1+(12e-3*mc_cgol_10V + 12e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
++ pfet_10v0_asym_DCJD='(1+(24e-3*mc_cgol_10V + 24e-3*mc_cgolp_10V)*sw_stat_global*mc_skew)'
 
 
 
 
-.LIB smbb000149.xyce nmos_10p0_asym_t
-
-
-
-
-
+.LIB smbb000149.xyce nfet_10v0_asym_t
 
 
 
@@ -292,16 +287,21 @@
 
 
 
-.LIB smbb000149.xyce pmos_10p0_asym_t
+
+
+
+
+
+.LIB smbb000149.xyce pfet_10v0_asym_t
 .LIB smbb000149.xyce noise_corner
 .ENDL
 *
 
 .LIB noise_corner
 .PARAM
-+ NMOS_10P0_ASYM_NOIA='(fnoicor==0)*1.1021E42 + (fnoicor==1)*2.5852e42' NMOS_10P0_ASYM_NOIB='(fnoicor==0)*2.8476E24 + (fnoicor==1)*6.5096e+024'
-+ NMOS_10P0_ASYM_NOIC='(fnoicor==0)*8.75 + (fnoicor==1)*8.75' PMOS_10P0_ASYM_NOIA='(fnoicor==0)*2.9073e+041 + (fnoicor==1)*1.7073e+042'
-+ PMOS_10P0_ASYM_NOIB='(fnoicor==0)*8.0736e+025 + (fnoicor==1)*2.4523e+026' PMOS_10P0_ASYM_NOIC='(fnoicor==0)*12780 + (fnoicor==1)*12780'
++ nfet_10v0_asym_NOIA='(fnoicor==0)*1.1021E42 + (fnoicor==1)*2.5852e42' nfet_10v0_asym_NOIB='(fnoicor==0)*2.8476E24 + (fnoicor==1)*6.5096e+024'
++ nfet_10v0_asym_NOIC='(fnoicor==0)*8.75 + (fnoicor==1)*8.75' pfet_10v0_asym_NOIA='(fnoicor==0)*2.9073e+041 + (fnoicor==1)*1.7073e+042'
++ pfet_10v0_asym_NOIB='(fnoicor==0)*8.0736e+025 + (fnoicor==1)*2.4523e+026' pfet_10v0_asym_NOIC='(fnoicor==0)*12780 + (fnoicor==1)*12780'
 .ENDL
 
 
@@ -314,9 +314,9 @@
 * 10V LDNMOS Asym Model
 ***************************************************************************************************
 *
-.LIB nmos_10p0_asym_t
+.LIB nfet_10v0_asym_t
 
-.SUBCKT nmos_10p0_asym d g s b
+.SUBCKT nfet_10v0_asym d g s b
 + PARAMS: W=25E-6 L=0.6E-6 AD='w*1.48e-6' PD='2*(1.48e-6+w)' AS='w*0.48e-6' PS='(w+0.48e-6)*2'
 + NRD=0 NRS=0 NF=1 DTEMP=0 SA=0 SB=0 SD=0 PAR=1
 .PARAM
@@ -338,29 +338,29 @@
 
 Rdrift d d2
 + TC1={trx1} TC2={trx2} M={nf}
-+ R='(rdrift1*nmos_10p0_asym_drdrift)*1.2e-6/(w/nf-wa)'
++ R='(rdrift1*nfet_10v0_asym_drdrift)*1.2e-6/(w/nf-wa)'
 Rd2 d2 d1
 + M={nf}
-+ R='max(1e-2, (rd*nmos_10p0_asym_drdsw*(1+trth1*(temp+dtemp-25)+trth2*(temp+dtemp-25)*(temp+dtemp-25)))/(w/nf-wb)*(tanh(ra*(v(d,s)-rb*(l-lb)/(0.6e-6-lb)))))'
-M0 d1 g s b nmos_10p0_asym_core
++ R='max(1e-2, (rd*nfet_10v0_asym_drdsw*(1+trth1*(temp+dtemp-25)+trth2*(temp+dtemp-25)*(temp+dtemp-25)))/(w/nf-wb)*(tanh(ra*(v(d,s)-rb*(l-lb)/(0.6e-6-lb)))))'
+M0 d1 g s b nfet_10v0_asym_core
 + AD={ad} AS={as} L={l} NF={nf} NRD={nrd} NRS={nrs} PD={pd} PS={ps} SA={sa}
 + SB={sb} SD={sd} W={w}
 C1_gd g d
-+ C='nmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1)) -nmos_10p0_asym_dvth0))))'
++ C='nfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1)) -nfet_10v0_asym_dvth0))))'
 C1_gd2 g d1
-+ C='nmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1))  -nmos_10p0_asym_dvth0 ) )) )'
++ C='nfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(v(d,g),0))*(v(g,d1)+cgd_vthd*(1+cgdv_d2*v(d,d1))  -nfet_10v0_asym_dvth0 ) )) )'
 C2_gs g s
-+ C='nmos_10p0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(-v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(v(d1,s)-vthd,0),polars_min)))))'
++ C='nfet_10v0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(-v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(v(d1,s)-vthd,0),polars_min)))))'
 C3_gb g b
-+ C='(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + nmos_10p0_asym_dvth0)), cgb_power))) ) *w '
-.MODEL nmos_10p0_asym_core.1 NMOS
++ C='(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(v(b,g)-cgb_vth + nfet_10v0_asym_dvth0)), cgb_power))) ) *w '
+.MODEL nfet_10v0_asym_core.1 NMOS
 + A0=1.0212 A1=-0.065307 A2=0.94 ACDE=0.54775 ACNQSMOD=0 AGIDL=5.7877E-16
 + AGS=0.13804 ALPHA0=-2.5481E-7 ALPHA1=0.59769 AT=3.3E4 B0=6.48E-6 B1=5.9519E-5
 + BETA0=37.485 BGIDL=1.171E9 BINUNIT=1 BVD=14.5 BVS=11 CAPMOD=2 CDSC=1.1424E-5
 + CDSCB=2.4894E-6 CDSCD=0 CGBO=1E-13 CGDL=0 CGDO=0 CGIDL=0.228 CGSL=0 CGSO=0
-+ CIT=0 CJD='1.4914E-4*nmos_10p0_asym_dcjd' CJS='9.5E-4*nmos_10p0_asym_dcjs'
-+ CJSWD='5.8719E-10*nmos_10p0_asym_dcjd' CJSWGD='5.8719E-10*nmos_10p0_asym_dcjd'
-+ CJSWGS='1.33E-10*nmos_10p0_asym_dcjs' CJSWS='1.33E-10*nmos_10p0_asym_dcjs'
++ CIT=0 CJD='1.4914E-4*nfet_10v0_asym_dcjd' CJS='9.5E-4*nfet_10v0_asym_dcjs'
++ CJSWD='5.8719E-10*nfet_10v0_asym_dcjd' CJSWGD='5.8719E-10*nfet_10v0_asym_dcjd'
++ CJSWGS='1.33E-10*nfet_10v0_asym_dcjs' CJSWS='1.33E-10*nfet_10v0_asym_dcjs'
 + CKAPPAD=0.6 CKAPPAS=0.6 DELTA=0.01 DIOMOD=2 DLC=1.723E-7 DROUT=0.45 DSUB=0.56
 + DVT0=0.09762 DVT0W=3.4488 DVT1=0.021131 DVT1W=9.5865E4 DVT2=-0.046683
 + DVT2W=0.034426 DVTP0=0 DVTP1=0 DWB=-3.3647E-8 DWG=-2.9807E-8 EF=1.0914
@@ -370,30 +370,30 @@ C3_gb g b
 + K3B=0.25485 KETA=-0.01362 KT1=-0.42425 KT1L=-1.8892E-8 KT2=-0.060553
 + LA0=-0.55504 LAGS=0 LAT=0 LBETA0=-11.164 LINT=0 LK1=0 LK2=0 LKETA=-3.3807E-3
 + LL=0 LLN=1 LMAX=20.01E-6 LMIN=6E-7 LNFACTOR=6.48E-7 LNOFF=1 LPE0=1.0439E-6
-+ LPEB=6.2517E-7 LU0='5.2003E-3*nmos_10p0_asym_du0' LUA=4.2194E-10 LUA1=0
++ LPEB=6.2517E-7 LU0='5.2003E-3*nfet_10v0_asym_du0' LUA=4.2194E-10 LUA1=0
 + LUB=-1.9302E-18 LUB1=0 LUC=-4.7702E-11 LUTE=0.045577
-+ LVSAT='9844*nmos_10p0_asym_dvsat' LVTH0=0 LW=0 LWL=0 LWN=1 MINV=0 MJD=0.30525
++ LVSAT='9844*nfet_10v0_asym_dvsat' LVTH0=0 LW=0 LWL=0 LWN=1 MINV=0 MJD=0.30525
 + MJS=0.296 MJSWD=0.21757 MJSWGD=0.21757 MJSWGS=0.01 MJSWS=0.01 MOBMOD=0
 + MOIN=16.92 NDEP=1.7E17 NFACTOR=0.90694 NGATE=2.9861E21 NJD=1 NJS=1.0541
-+ NOFF=1.9257 NOIA='nmos_10p0_asym_noia' NOIB='nmos_10p0_asym_noib'
-+ NOIC='nmos_10p0_asym_noic' NSD=1E20 PARAMCHK=1 PAT=-9E3 PBD=0.43905
++ NOFF=1.9257 NOIA='nfet_10v0_asym_noia' NOIB='nfet_10v0_asym_noib'
++ NOIC='nfet_10v0_asym_noic' NSD=1E20 PARAMCHK=1 PAT=-9E3 PBD=0.43905
 + PBETA0=-0.645 PBS=0.606 PBSWD=0.48991 PBSWGD=0.48991 PBSWGS=0.48 PBSWS=0.48
 + PCLM=0.02794 PDIBLC1=0.46226 PDIBLC2=1.092E-4 PDIBLCB=-5E-3 PERMOD=1 PHIN=0
 + PKT1=0 PKT2=-0.09625 PPRT=0 PPRWB=0 PPRWG=0 PRDSW=0 PRT=200 PRWB=0.81
 + PRWG=0.037838 PSCBE1=4.9654E8 PSCBE2=1.6381E-7
-+ PU0='3.9064E-3*nmos_10p0_asym_du0' PUA=0 PUA1=0 PUB=-6.8E-19 PUB1=0
++ PU0='3.9064E-3*nfet_10v0_asym_du0' PUA=0 PUA1=0 PUB=-6.8E-19 PUB1=0
 + PUC=-6.8588E-11 PUTE=0.17695 PVAG=0.9 PVSAT=-3.168E3 PVTH0=0.19879 RBODYMOD=0
-+ RDSMOD=0 RDSW='200*nmos_10p0_asym_drdsw' RDSWMIN=500 RSH=7 TCJ=1.65E-3
++ RDSMOD=0 RDSW='200*nfet_10v0_asym_drdsw' RDSWMIN=500 RSH=7 TCJ=1.65E-3
 + TCJSW=1.61E-3 TCJSWG=1.61E-3 TEMPMOD=0 TNOIMOD=0 TNOM=25
-+ TOXE='1.398E-8+nmos_10p0_asym_dtox' TPB=2.11E-3 TPBSW=1.9E-3 TPBSWG=1.9E-3
-+ TRNQSMOD=0 U0='0.0486*nmos_10p0_asym_du0' UA=-1.05E-10 UA1=3.2446E-9
++ TOXE='1.398E-8+nfet_10v0_asym_dtox' TPB=2.11E-3 TPBSW=1.9E-3 TPBSWG=1.9E-3
++ TRNQSMOD=0 U0='0.0486*nfet_10v0_asym_du0' UA=-1.05E-10 UA1=3.2446E-9
 + UB=3.0678E-18 UB1=-4.2148E-18 UC=1.0312E-10 UC1=-7.2993E-11 UTE=-1.3028
 + VFB=-0.55 VOFF=-0.092552 VOFFCV=-0.038 VOFFL=-1.4059E-8
-+ VSAT='7.9784E4*nmos_10p0_asym_dvsat' VTH0='0.653 +nmos_10p0_asym_dvth0'
++ VSAT='7.9784E4*nfet_10v0_asym_dvsat' VTH0='0.653 +nfet_10v0_asym_dvth0'
 + VTSD=2.16 W0=1E-6 WAGS=-0.012 WBETA0=2.034 WINT=0 WK3=0 WKT1=0 WL=0 WLN=1
-+ WMAX=50.01E-6 WMIN=4E-6 WR=1 WU0='-0.020672*nmos_10p0_asym_du0' WVSAT=0 WVTH0=0
-+ WW=0 WWL=0 WWN=1 XJ=1.5E-7 XJBVD=1 XJBVS=1 XL='0+nmos_10p0_asym_dxl' XPART=1
-+ XTID=3 XTIS=3 XTSD=0.63818 XW='0+nmos_10p0_asym_dxw'
++ WMAX=50.01E-6 WMIN=4E-6 WR=1 WU0='-0.020672*nfet_10v0_asym_du0' WVSAT=0 WVTH0=0
++ WW=0 WWL=0 WWN=1 XJ=1.5E-7 XJBVD=1 XJBVS=1 XL='0+nfet_10v0_asym_dxl' XPART=1
++ XTID=3 XTIS=3 XTSD=0.63818 XW='0+nfet_10v0_asym_dxw'
 + LEVEL=14
 ***** Flag Parameter ***
 ***** Geometry Range Parameter ***
@@ -425,7 +425,7 @@ C3_gb g b
 
 
 
-.ENDS nmos_10p0_asym
+.ENDS nfet_10v0_asym
 
 
 
@@ -437,7 +437,7 @@ C3_gb g b
 
 
 
-.ENDL nmos_10p0_asym_t
+.ENDL nfet_10v0_asym_t
 
 *
 
@@ -445,9 +445,9 @@ C3_gb g b
 * 10V LDPMOS Asym Model
 ***************************************************************************************************
 *
-.LIB pmos_10p0_asym_t
+.LIB pfet_10v0_asym_t
 
-.SUBCKT pmos_10p0_asym d g s b
+.SUBCKT pfet_10v0_asym d g s b
 + PARAMS: W=2.5E-5 L=6E-7 DTEMP=0 NF=1 AD='(w*1.78e-6)' PD='2*(w+1.78e-6)' AS='w*0.48e-6'
 + PS='(w+0.48e-6)*2' NRD=0 NRS=0 SA=0 SB=0 SD=0 PAR=1
 .PARAM
@@ -467,31 +467,31 @@ C3_gb g b
 
 
 Rd1 d d2
-+ TC1={trx1} TC2={trx2} M={nf} R='(rdrift*pmos_10p0_asym_drdrift)/(w/nf-wa)'
++ TC1={trx1} TC2={trx2} M={nf} R='(rdrift*pfet_10v0_asym_drdrift)/(w/nf-wa)'
 Rd2 d2 d1
 + M={nf}
-+ R='max(0.1, (rd*pmos_10p0_asym_drdsw*(1+trd1*(temp+dtemp-25))/(w/nf-wb)*(tanh(ra*(v(s,d)-rb*(l-lb)/(0.6e-6-lb))))))'
-M0 d1 g s b pmos_10p0_asym_core
++ R='max(0.1, (rd*pfet_10v0_asym_drdsw*(1+trd1*(temp+dtemp-25))/(w/nf-wb)*(tanh(ra*(v(s,d)-rb*(l-lb)/(0.6e-6-lb))))))'
+M0 d1 g s b pfet_10v0_asym_core
 + AD={ad} AS={as} L={l} NF={nf} NRD={nrd} NRS={nrs} PD={pd} PS={ps} SA={sa}
 + SB={sb} SD={sd} W={w}
 C1_gd g d
-+ C='pmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(-v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pmos_10p0_asym_dvth0))))'
++ C='pfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d+ exp(polar_d*min(max(-v(d,s)-vthd,0),polard_min))*cgdl_d*w*(1+tanh(cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pfet_10v0_asym_dvth0))))'
 C1_gd2 g d1
-+ C='pmos_10p0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pmos_10p0_asym_dvth0   ) )) )'
++ C='pfet_10v0_asym_dcgd*(cgds_fixed*w*lcgd_d2 + cgdl_d2*w*(1+tanh( cgdv_d/(1+cgd_val*max(-v(d,g),0))*(-v(g,d1)+cgd_vthd*(1+cgdv_d2*-v(d,d1)) - pfet_10v0_asym_dvth0   ) )) )'
 C2_gs g s
-+ C='pmos_10p0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(-v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(-v(d1,s)-vthd,0),polars_min)))))'
++ C='pfet_10v0_asym_dcgs*(cgds_fixed*w*lcgs + cgsl_s*w*(1-tanh(cgs_slope*(-v(s,g)+cgs_vth)))*(1 +cgs_factor/(1+cgs_factor2*exp(v(g,d1)-cgs_vth1))*(1- exp(polar_s*min(max(-v(d1,s)-vthd,0),polars_min)))))'
 C3_gb g b
-+ C='(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + pmos_10p0_asym_dvth0)), cgb_power))) ) *w '
-.MODEL pmos_10p0_asym_core.1 PMOS
++ C='(cgb_min +  cgb_amp/(1+(1/pow(max(1e-3, cgb_slope*(-v(b,g)-cgb_vth + pfet_10v0_asym_dvth0)), cgb_power))) ) *w '
+.MODEL pfet_10v0_asym_core.1 PMOS
 + A0=1.1348 A1=-0.07052 A2=1 ACDE=1 ACNQSMOD=0 AGIDL=3.7498E-17 AGS=0.0834
 + AIGBACC=0.43 AIGBINV=0.35 AIGC=0.43 AIGSD=0.43 ALPHA0=7.0634E-8 ALPHA1=0.14712
 + AT=3.96E3 B0=0 B1=0 BETA0=66.68 BGIDL=1.196E8 BIGBACC=0.054 BIGBINV=0.03
 + BIGC=0.054 BIGSD=0.054 BINUNIT=2 BVD=14.5 BVS=10.5 CAPMOD=2 CDSC=4.248E-4
 + CDSCB=6E-5 CDSCD=0 CGBO=0 CGDL=0 CGDO=0 CGIDL=0.5 CGSL=0 CGSO=0 CIGBACC=0.075
-+ CIGBINV=6E-3 CIGC=0.075 CIGSD=0.075 CIT=0 CJD='3.2124E-4*pmos_10p0_asym_dcjd'
-+ CJS='9.12E-4*pmos_10p0_asym_dcjs' CJSWD='5.4659E-10*pmos_10p0_asym_dcjd'
-+ CJSWGD='5.4659E-10*pmos_10p0_asym_dcjd' CJSWGS='1.4649E-10*pmos_10p0_asym_dcjs'
-+ CJSWS='1.4649E-10*pmos_10p0_asym_dcjs' CKAPPAD=0.6 CKAPPAS=0.6 CLC=1E-7 CLE=0.6
++ CIGBINV=6E-3 CIGC=0.075 CIGSD=0.075 CIT=0 CJD='3.2124E-4*pfet_10v0_asym_dcjd'
++ CJS='9.12E-4*pfet_10v0_asym_dcjs' CJSWD='5.4659E-10*pfet_10v0_asym_dcjd'
++ CJSWGD='5.4659E-10*pfet_10v0_asym_dcjd' CJSWGS='1.4649E-10*pfet_10v0_asym_dcjs'
++ CJSWS='1.4649E-10*pfet_10v0_asym_dcjs' CKAPPAD=0.6 CKAPPAS=0.6 CLC=1E-7 CLE=0.6
 + DELTA=0.01 DIOMOD=0 DLC=5.0579E-8 DROUT=0.56 DSUB=0.56 DVT0=4.0503 DVT0W=0
 + DVT1=0.16044 DVT1W=2.7518E4 DVT2=-0.038473 DVT2W=-0.032 DVTP0=0 DVTP1=0 DWB=0
 + DWG=1.0544E-8 EF=1.1237 EGIDL=0.8 EIGBINV=1.1 EM=4.1E7 EPSROX=3.9 ETA0=0.08
@@ -500,30 +500,30 @@ C3_gb g b
 + JSWS=1.6088E-13 JTSD=1.0891E-6 K1=1.09 K2=-0.014623 K3=5.4746 K3B=3.8727
 + KETA=-1.504E-3 KT1=-0.45028 KT1L=-4.1552E-8 KT2=-0.05137 LA0=-3.8459E-7 LAGS=0
 + LBETA0=-2.1875E-6 LINT=0 LKETA=-2.0415E-8 LL=0 LLPE0=0 LMAX=20.01E-6 LMIN=6E-7
-+ LNOFF=1.2657E-6 LPE0=2.814E-7 LPEB=3.068E-7 LU0='2.7385E-9*pmos_10p0_asym_du0'
++ LNOFF=1.2657E-6 LPE0=2.814E-7 LPEB=3.068E-7 LU0='2.7385E-9*pfet_10v0_asym_du0'
 + LUA=1.2893E-16 LUA1=0 LUB=0 LUB1=-2.0019E-25 LUC=5.88E-17 LUC1=0
 + LUTE=-1.1751E-7 LWL=0 MINV=0 MJD=0.31113 MJS=0.32713 MJSWD=0.39816
 + MJSWGD=0.39816 MJSWGS=0.056777 MJSWS=0.056777 MOBMOD=0 MOIN=11.1 NDEP=1.7E17
 + NFACTOR=1.096 NGATE=1E20 NIGBACC=1 NIGBINV=3 NIGC=1 NOFF=1.8144
-+ NOIA='pmos_10p0_asym_noia' NOIB='pmos_10p0_asym_noib'
-+ NOIC='pmos_10p0_asym_noic' NSD=1E20 NTOX=1 PAGS=6.4229E-13 PARAMCHK=1
++ NOIA='pfet_10v0_asym_noia' NOIB='pfet_10v0_asym_noib'
++ NOIC='pfet_10v0_asym_noic' NSD=1E20 NTOX=1 PAGS=6.4229E-13 PARAMCHK=1
 + PBD=0.63391 PBETA0=0 PBS=0.76836 PBSWD=0.77752 PBSWGD=0.77752 PBSWGS=0.5
 + PBSWS=0.5 PCLM=0.37315 PDIBLC1=0.09466 PDIBLC2=5.586E-8 PDIBLCB=0 PDITS=0
 + PDITSD=0 PDITSL=0 PDVT0=-2.3525E-12 PDVT1=0 PERMOD=1 PHIN=0.061992 PIGCD=1
 + PK2=-9.04E-14 PKETA=-7.5094e-014 PKT1=0 PKT2=-1.1E-13 PLPE0=0 POXEDGE=1 PRT=0
 + PRWB=1.24 PRWG=1 PSCBE1=5.9843E8 PSCBE2=9.3757E-8
-+ PU0='-2E-15*pmos_10p0_asym_du0' PUA=6.315E-22 PUTE=1.0911E-13 PVAG=1.2 PVSAT=0
-+ PVTH0=1.44E-14 RBODYMOD=0 RDSMOD=0 RDSW='200*pmos_10p0_asym_drdsw' RDSWMIN=0
++ PU0='-2E-15*pfet_10v0_asym_du0' PUA=6.315E-22 PUTE=1.0911E-13 PVAG=1.2 PVSAT=0
++ PVTH0=1.44E-14 RBODYMOD=0 RDSMOD=0 RDSW='200*pfet_10v0_asym_drdsw' RDSWMIN=0
 + RDW=100 RDWMIN=0 RSH=5.6 RSHG=0.4 RSW=100 RSWMIN=0 TEMPMOD=0 TNOIMOD=0
-+ TOXE='1.568E-8+pmos_10p0_asym_dtox' TRNQSMOD=0 U0='0.013723*pmos_10p0_asym_du0'
++ TOXE='1.568E-8+pfet_10v0_asym_dtox' TRNQSMOD=0 U0='0.013723*pfet_10v0_asym_du0'
 + UA=1.26E-9 UA1=5E-10 UB=7.2608E-19 UB1=-2.2324E-18 UC=-4.5217E-11
 + UC1=-3.0912E-11 UTE=-1.245 VBM=-3 VFB=-1 VFBCV=-1 VOFF=-0.08768
-+ VOFFCV=-3.8635E-3 VOFFL=0 VSAT='71505*pmos_10p0_asym_dvsat'
-+ VTH0='-0.888+pmos_10p0_asym_dvth0' VTSD=2.44 W0=3.24E-6 WAGS=6.5664E-9
++ VOFFCV=-3.8635E-3 VOFFL=0 VSAT='71505*pfet_10v0_asym_dvsat'
++ VTH0='-0.888+pfet_10v0_asym_dvth0' VTSD=2.44 W0=3.24E-6 WAGS=6.5664E-9
 + WBETA0=4.86E-6 WDVT0=0 WDVT1=0 WINT=0 WK2=0 WKETA=2.68e-008 WKT1=0
-+ WLPE0=-3.5894E-13 WMAX=50.01e-6 WMIN=4e-6 WR=1 WU0='-7E-10*pmos_10p0_asym_du0'
++ WLPE0=-3.5894E-13 WMAX=50.01e-6 WMIN=4e-6 WR=1 WU0='-7E-10*pfet_10v0_asym_du0'
 + WUTE=-4E-8 WVSAT=0 WVTH0=0 WW=0 WWL=0 XJ=1.5E-7 XJBVD=1 XJBVS=1
-+ XL=' 0 + pmos_10p0_asym_dxl' XTSD=0.92538 XW='0+ pmos_10p0_asym_dxw'
++ XL=' 0 + pfet_10v0_asym_dxl' XTSD=0.92538 XW='0+ pfet_10v0_asym_dxw'
 + LEVEL=14
 ***** Flag Parameter ***
 ***** Geometry Range Parameter ***
@@ -566,14 +566,14 @@ C3_gb g b
 
 
 
-.ENDS pmos_10p0_asym
+.ENDS pfet_10v0_asym
 
 
 
 
 
 
-.ENDL pmos_10p0_asym_t
+.ENDL pfet_10v0_asym_t
 
 
 

--- a/models/xyce/testing/regression/mimcap_c/models_regression.py
+++ b/models/xyce/testing/regression/mimcap_c/models_regression.py
@@ -129,7 +129,10 @@ def main():
 
     # 3p3
     corners = ["ss" , "typical","ff"]        
-    devices = ["mim_1p5fF" , "mim_1p0fF" , "mim_2p0fF"]
+    devices = ["cap_mim_1f5_m2m3_noshield" , "cap_mim_1f0_m2m3_noshield" , "cap_mim_2f0_m2m3_noshield" ,\
+               "cap_mim_1f5_m3m4_noshield" , "cap_mim_1f0_m3m4_noshield" , "cap_mim_2f0_m3m4_noshield" ,\
+               "cap_mim_1f5_m4m5_noshield" , "cap_mim_1f0_m4m5_noshield" , "cap_mim_2f0_m4m5_noshield" ,\
+               "cap_mim_1f5_m5m6_noshield" , "cap_mim_1f0_m5m6_noshield" , "cap_mim_2f0_m5m6_noshield" ]
     measure = ["cv","corners", "CV (fF)"]
     voltage = ["-3.0 3.0 0.1"]
     start = 0


### PR DESCRIPTION
Fixes https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/issues/1

- Renaming all primitives with its new name except [resistors / sc_diode] in the following directory

  -  globalfoundries-pdk-libs-gf180mcu_fd_pr/models
